### PR TITLE
Changed "Development" to "Installation" in header

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo is in the early stages of development, stay tuned for when we are read
 
 There is a front-end portion of this project under development at [Human Services Finder](https://github.com/codeforamerica/human_services_finder)
 
-## Development Details
+## Installation Details
 
 (COMING SOON...)
 


### PR DESCRIPTION
I’ve made a tiny change to the README. I have been working on a checklist for required headings in documentation, and starting to write tests against them. “Installation” reflects the content of this section slightly better, and will also pass the [tests I’ve been working on](http://github-observer.s3.amazonaws.com/observations.html). Humor me? 
