### PR TITLE
Add nearby endpoint for locations near the one queried. Fixes #15.

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -18,6 +18,11 @@ module Api
         expose Organization.find(params[:id])
       end
 
+      def nearby
+        org = Organization.find(params[:id])
+        expose org.nearbys(current_radius)
+      end
+
       def search
         @results = org_search(params).all.page(params[:page]).per(30)
         begin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ OhanaApi::Application.routes.draw do
     scope module: :v1, constraints: ApiConstraints.new(1) do
       resources :organizations
   		get 'search', :to => 'organizations#search'
+      get 'organizations/:id/nearby', :to => 'organizations#nearby'
 		end
   end
 end

--- a/spec/controllers/api/v1/organizations_controller_spec.rb
+++ b/spec/controllers/api/v1/organizations_controller_spec.rb
@@ -280,4 +280,37 @@ describe Api::V1::OrganizationsController do
       end
     end
   end
+
+  describe "GET 'nearby'" do
+    before :each do
+      @organization = create(:organization)
+      nearby = create(:nearby_org)
+    end
+
+    context 'with no radius' do
+      it "displays nearby locations within 2 miles" do
+        get :nearby, :id => @organization
+        response.parsed_body["count"].should == 1
+        name = response.parsed_body["response"][0]["name"]
+        name.should == 'Redwood City Main'
+      end
+    end
+
+    context 'with valid radius' do
+      it "displays nearby locations within 5 miles" do
+        get :nearby, :id => @organization, :radius => 5
+        response.parsed_body["count"].should == 1
+        name = response.parsed_body["response"][0]["name"]
+        name.should == 'Redwood City Main'
+      end
+    end
+
+    context 'with invalid radius' do
+      it "returns 'invalid radius' message" do
+        get :nearby, :id => @organization, :radius => "<script>"
+        specific_reason = response.parsed_body["specific_reason"]
+        specific_reason.should == "radius must be a number"
+      end
+    end
+  end
 end


### PR DESCRIPTION
`radius` is optional parameter. Defaults to 2.
Example query: `api/organizations/51de30b71974fc3e7b00040b/nearby?radius=0.25`
