### PR TITLE
Make import rake task at least twice as fast

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -81,7 +81,6 @@ class Location < ActiveRecord::Base
   accepts_nested_attributes_for :phones
 
   has_many :services, dependent: :destroy
-  after_touch() { tire.update_index }
   accepts_nested_attributes_for :services
 
   #has_many :schedules, dependent: :destroy
@@ -186,7 +185,14 @@ class Location < ActiveRecord::Base
 
   ## ELASTICSEARCH
   include Tire::Model::Search
-  include Tire::Model::Callbacks
+
+  after_save    :update_tire_index
+  after_destroy :update_tire_index
+  after_touch   :update_tire_index
+
+  def update_tire_index
+    tire.update_index
+  end
 
   #paginates_per Rails.env.test? ? 1 : 30
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -24,8 +24,8 @@ class Organization < ActiveRecord::Base
 
   paginates_per Rails.env.test? ? 1 : 30
 
-  after_save :refresh_tire_index
-  def refresh_tire_index
+  after_save :update_tire_index
+  def update_tire_index
     self.locations.each { |loc| loc.tire.update_index }
   end
 

--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -1,0 +1,13 @@
+# Hat tip to Brent Collier:
+# http://intridea.com/blog/2009/3/12/temporarily-disable-activerecord-callbacks
+
+class ActiveRecord::Base
+  def self.without_callback(callback, &block)
+    method = self.send(:instance_method, callback)
+    self.send(:remove_method, callback)
+    self.send(:define_method, callback) { true }
+    yield
+    self.send(:remove_method, callback)
+    self.send(:define_method, callback, method)
+  end
+end

--- a/lib/tasks/setup_db.rake
+++ b/lib/tasks/setup_db.rake
@@ -16,7 +16,9 @@ task :load_data => :environment do
 
     locs = data_item["locations"]
     locs.each do |location|
-      org.locations.create!(location)
+      Location.without_callback(:update_tire_index) do
+        Location.create!(location.merge(organization_id: org.id))
+      end
     end
   end
   puts "===> Done populating the DB with #{file}."

--- a/spec/api/locations_spec.rb
+++ b/spec/api/locations_spec.rb
@@ -705,6 +705,12 @@ describe Ohana::API do
         expect { Service.find(@service_id) }.
           to raise_error(ActiveRecord::RecordNotFound)
       end
+
+      it "updates the search index" do
+        @location.index.refresh
+        get "api/search?keyword=vrs"
+        expect(json.length).to eq(0)
+      end
     end
 
   end


### PR DESCRIPTION
Disable Elasticsearch indexing callbacks during bulk data import. This, unsurprisingly, tremendously speeds up the import, by up to 3x according to my initial tests.
