### PR TITLE
Run migrations on Heroku after loading schema

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,6 +92,11 @@ OhanaApi::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  # Set the schema format to ruby until we upgrade to Rails 4.1,
+  # at which point we can use the setting below instead.
+  # This is to suppress the "Error dumping database" message on Heroku.
+  config.active_record.schema_format = :ruby
+
   # Do not dump schema after migrations.
   # This is a Rails 4.1 setting. Uncomment after upgrading.
   # config.active_record.dump_schema_after_migration = false

--- a/script/setup_prod_db
+++ b/script/setup_prod_db
@@ -2,10 +2,11 @@
 
 set -e
 
-echo "===> Creating ohana-api_production database..."
-rake db:create:all
 echo "===> Loading the DB schema..."
 rake db:schema:load
 
-echo "===> Populating up the DB..."
+echo "===> Running the migrations..."
+rake db:migrate
+
+echo "===> Populating the DB..."
 rake setup_db


### PR DESCRIPTION
Because we have migrations that execute SQL that ActiveRecord can't handle, we need to run "rake db:migrate" after "rake db:schema:load" to run those migrations.
