### PR TITLE
Sort categories by oe_id

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -19,6 +19,8 @@ class Category < ActiveRecord::Base
 
   validates_presence_of :name, :oe_id, message: "can't be blank for Category"
 
+  default_scope order("oe_id ASC")
+
   include Grape::Entity::DSL
   entity do
     expose :id

--- a/spec/api/categories_spec.rb
+++ b/spec/api/categories_spec.rb
@@ -80,5 +80,106 @@ describe Ohana::API do
         expect(json.first['name']).to eq('Community Gardens')
       end
     end
+
+    describe 'order categories by oe_id' do
+      include Features::SessionHelpers
+
+      before :each do
+        @food = Category.create!(name: 'Food', oe_id: '101')
+        @food_child = @food.children.
+          create!(name: 'Community Gardens', oe_id: '101-01')
+        @dental = Category.create!(name: 'Dental', oe_id: '102')
+        @dental_child = @dental.children.
+          create!(name: 'Orthodontics', oe_id: '102-01')
+        create_service
+        cat_ids = []
+        [@food, @food_child, @dental, @dental_child].each do |cat|
+          cat_ids.push(cat.id)
+        end
+        @service.category_ids = cat_ids
+      end
+
+      it "orders the categories by oe_id" do
+        get "api/locations/#{@location.id}"
+
+        path = "#{ENV['API_BASE_URL']}organizations"
+
+        service_formatted_time = @location.services.first.updated_at.
+          strftime('%Y-%m-%dT%H:%M:%S.%3N%:z')
+
+        location_formatted_time = @location.updated_at.
+          strftime('%Y-%m-%dT%H:%M:%S.%3N%:z')
+
+        locations_url = "#{path}/#{@location.organization.id}/locations"
+
+        represented = {
+          'id' => @location.id,
+          'accessibility' => @location.accessibility.map(&:text),
+          'address' => {
+            'id'     => @location.address.id,
+            'street' => @location.address.street,
+            'city'   => @location.address.city,
+            'state'  => @location.address.state,
+            'zip'    => @location.address.zip
+          },
+          'coordinates' => @location.coordinates,
+          'description' => @location.description,
+          'name' => @location.name,
+          'short_desc' => 'short description',
+          'slug' => 'vrs-services',
+          'updated_at' => location_formatted_time,
+          'url' => "#{ENV['API_BASE_URL']}locations/#{@location.id}",
+          'services' => [{
+            'id' => @location.services.reload.first.id,
+            'description' => @location.services.first.description,
+            'keywords' => @location.services.first.keywords,
+            'categories' => [
+              {
+                'id'    => @food.id,
+                'depth' => 0,
+                'oe_id' => '101',
+                'name'  => 'Food',
+                'parent_id' => nil,
+                'slug' => 'food'
+              },
+              {
+                'id'    => @food_child.id,
+                'depth' => 1,
+                'oe_id' => '101-01',
+                'name'  => 'Community Gardens',
+                'parent_id' => @food.id,
+                'slug' => 'community-gardens'
+              },
+              {
+                'id'    => @dental.id,
+                'depth' => 0,
+                'oe_id' => '102',
+                'name'  => 'Dental',
+                'parent_id' => nil,
+                'slug' => 'dental'
+              },
+              {
+                'id'    => @dental_child.id,
+                'depth' => 1,
+                'oe_id' => '102-01',
+                'name'  => 'Orthodontics',
+                'parent_id' => @dental.id,
+                'slug' => 'orthodontics'
+              },
+            ],
+            'name' => @location.services.first.name,
+            'updated_at' => service_formatted_time
+          }],
+          'organization' => {
+            'id' => @location.organization.id,
+            'name' => 'Parent Agency',
+            'slug' => 'parent-agency',
+            'url' => "#{path}/#{@location.organization.id}",
+            'locations_url' => locations_url
+          }
+        }
+        json.should == represented
+      end
+    end
   end
 end


### PR DESCRIPTION
To make it easier for clients to display a service's categories in the proper
nested order, categories should be sorted by oe_id by default.
