### PR TITLE
Add number_type column to Phones table

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -19,7 +19,7 @@ class Category < ActiveRecord::Base
 
   validates_presence_of :name, :oe_id, message: "can't be blank for Category"
 
-  default_scope order("oe_id ASC")
+  default_scope { order('oe_id ASC') }
 
   include Grape::Entity::DSL
   entity do

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -36,6 +36,8 @@ class Organization < ActiveRecord::Base
     URI.parse(urls.first).host.gsub(/^www\./, '') if urls.present?
   end
 
+  default_scope { order('id ASC') }
+
   include Grape::Entity::DSL
   entity do
     expose :id

--- a/app/models/phone.rb
+++ b/app/models/phone.rb
@@ -1,17 +1,22 @@
 class Phone < ActiveRecord::Base
   belongs_to :location, touch: true
 
-  normalize_attributes :department, :extension, :number, :vanity_number
+  normalize_attributes :department, :extension, :number, :number_type,
+                       :vanity_number
 
   validates_presence_of :number, message: "can't be blank for Phone"
 
   validates_formatting_of(
     :number,
     using: :us_phone,
-    message: '%{value} is not a valid US phone number'
+    message: '%{value} is not a valid US phone number',
+    unless: ->(phone) { phone.number == '711' }
   )
 
-  attr_accessible :department, :extension, :number, :vanity_number
+  attr_accessible :department, :extension, :number, :number_type,
+                  :vanity_number
+
+  default_scope { order('id ASC') }
 
   include Grape::Entity::DSL
   entity do
@@ -19,6 +24,7 @@ class Phone < ActiveRecord::Base
     expose :department, unless: ->(o, _) { o.department.blank? }
     expose :extension, unless: ->(o, _) { o.extension.blank? }
     expose :number, unless: ->(o, _) { o.number.blank? }
+    expose :number_type, unless: ->(o, _) { o.number_type.blank? }
     expose :vanity_number, unless: ->(o, _) { o.vanity_number.blank? }
   end
 end

--- a/db/migrate/20140522153640_add_number_type_to_phones.rb
+++ b/db/migrate/20140522153640_add_number_type_to_phones.rb
@@ -1,0 +1,5 @@
+class AddNumberTypeToPhones < ActiveRecord::Migration
+  def change
+    add_column :phones, :number_type, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -400,39 +400,6 @@ ALTER SEQUENCE organizations_id_seq OWNED BY organizations.id;
 
 
 --
--- Name: pg_search_documents; Type: TABLE; Schema: public; Owner: -; Tablespace: 
---
-
-CREATE TABLE pg_search_documents (
-    id integer NOT NULL,
-    content text,
-    searchable_id integer,
-    searchable_type character varying(255),
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone
-);
-
-
---
--- Name: pg_search_documents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE pg_search_documents_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: pg_search_documents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE pg_search_documents_id_seq OWNED BY pg_search_documents.id;
-
-
---
 -- Name: phones; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -444,7 +411,8 @@ CREATE TABLE phones (
     extension text,
     vanity_number text,
     created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    number_type character varying(255)
 );
 
 
@@ -631,13 +599,6 @@ ALTER TABLE ONLY organizations ALTER COLUMN id SET DEFAULT nextval('organization
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY pg_search_documents ALTER COLUMN id SET DEFAULT nextval('pg_search_documents_id_seq'::regclass);
-
-
---
--- Name: id; Type: DEFAULT; Schema: public; Owner: -
---
-
 ALTER TABLE ONLY phones ALTER COLUMN id SET DEFAULT nextval('phones_id_seq'::regclass);
 
 
@@ -725,14 +686,6 @@ ALTER TABLE ONLY mail_addresses
 
 ALTER TABLE ONLY organizations
     ADD CONSTRAINT organizations_pkey PRIMARY KEY (id);
-
-
---
--- Name: pg_search_documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
---
-
-ALTER TABLE ONLY pg_search_documents
-    ADD CONSTRAINT pg_search_documents_pkey PRIMARY KEY (id);
 
 
 --
@@ -1024,13 +977,9 @@ INSERT INTO schema_migrations (version) VALUES ('20140402222453');
 
 INSERT INTO schema_migrations (version) VALUES ('20140404220233');
 
-INSERT INTO schema_migrations (version) VALUES ('20140422221247');
-
 INSERT INTO schema_migrations (version) VALUES ('20140424182454');
 
 INSERT INTO schema_migrations (version) VALUES ('20140505011725');
-
-INSERT INTO schema_migrations (version) VALUES ('20140505132443');
 
 INSERT INTO schema_migrations (version) VALUES ('20140508030435');
 
@@ -1039,3 +988,5 @@ INSERT INTO schema_migrations (version) VALUES ('20140508030926');
 INSERT INTO schema_migrations (version) VALUES ('20140508031024');
 
 INSERT INTO schema_migrations (version) VALUES ('20140508194831');
+
+INSERT INTO schema_migrations (version) VALUES ('20140522153640');

--- a/spec/api/categories_spec.rb
+++ b/spec/api/categories_spec.rb
@@ -99,7 +99,7 @@ describe Ohana::API do
         @service.category_ids = cat_ids
       end
 
-      it "orders the categories by oe_id" do
+      it 'orders the categories by oe_id' do
         get "api/locations/#{@location.id}"
 
         path = "#{ENV['API_BASE_URL']}organizations"
@@ -165,7 +165,7 @@ describe Ohana::API do
                 'name'  => 'Orthodontics',
                 'parent_id' => @dental.id,
                 'slug' => 'orthodontics'
-              },
+              }
             ],
             'name' => @location.services.first.name,
             'updated_at' => service_formatted_time

--- a/spec/models/phone_spec.rb
+++ b/spec/models/phone_spec.rb
@@ -8,11 +8,11 @@ describe Phone do
 
   it { should belong_to :location }
 
-  it { should allow_mass_assignment_of(:number) }
-  it { should allow_mass_assignment_of(:extension) }
   it { should allow_mass_assignment_of(:department) }
+  it { should allow_mass_assignment_of(:extension) }
+  it { should allow_mass_assignment_of(:number) }
+  it { should allow_mass_assignment_of(:number_type) }
   it { should allow_mass_assignment_of(:vanity_number) }
-
   it do
     should normalize_attribute(:number).
       from(' 703 555-1212  ').to('703 555-1212')
@@ -40,6 +40,10 @@ describe Phone do
 
   it do
     should allow_value('703-555-1212', '800.123.4567').for(:number)
+  end
+
+  it do
+    should allow_value('711').for(:number)
   end
 
   it do


### PR DESCRIPTION
Note that in ActiveRecord, naming a table column "type" implies you're using Single Table Inheritance. You can override that, but I thought it would be easier to just use a different name for the column.
