### PR TITLE
Add full-text search for org name

### DIFF
--- a/app/api/ohana.rb
+++ b/app/api/ohana.rb
@@ -495,13 +495,18 @@ module Ohana
 
             ### org_name
 
-            This parameter allows you to filter locations that belong to a
-            specific organization.
+            This parameter allows you to filter locations that belong to an
+            organization whose name matches all the terms passed in the
+            org_name parameter.
 
             Example:
             ```
-            #{ENV['API_BASE_URL']}search?org_name=San+Mateo+County+Human+Services+Agency
+            #{ENV['API_BASE_URL']}search?org_name=peninsula+service
             ```
+
+            Given 2 organization names, `Peninsula Family Service` and
+            `Peninsula Volunteers`, the search above will only return
+            locations that belong to `Peninsula Family Service`.
 
             ### location, radius
             Queries that include the `location` parameter filter the results to

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -183,7 +183,12 @@ class Location < ActiveRecord::Base
     near(coords, current_radius(r)) if l.present?
   end)
 
-  scope :belongs_to_org, ->(org) { joins(:organization).where(organizations: { name: org }) if org.present? }
+  scope :belongs_to_org, (lambda do |org|
+    if org.present?
+      joins(:organization).where('organizations.name @@ :q', q: org)
+    end
+  end)
+
   scope :has_email, ->(e) { where('admin_emails @@ :q or emails @@ :q', q: e) if e.present? }
 
   scope :has_domain, (lambda do |domain|

--- a/spec/api/search_spec.rb
+++ b/spec/api/search_spec.rb
@@ -261,11 +261,19 @@ describe Ohana::API do
       before(:each) do
         create(:nearby_loc)
         create(:location)
+        create(:soup_kitchen)
       end
-      it 'only returns locations whose org name matches the query' do
-        get 'api/search?org_name=Food+Stamps'
+
+      it 'returns results when org_name only contains one word that matches' do
+        get 'api/search?org_name=stamps'
         expect(headers['X-Total-Count']).to eq '1'
         json.first['name'].should == 'Library'
+      end
+
+      it 'only returns locations whose org name matches all terms' do
+        get 'api/search?org_name=Food+Pantry'
+        expect(headers['X-Total-Count']).to eq '1'
+        json.first['name'].should == 'Soup Kitchen'
       end
     end
 

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -58,4 +58,12 @@ FactoryGirl.define do
     latitude 37.568272
     longitude(-122.3250474)
   end
+
+  factory :soup_kitchen, class: Location do
+    name 'Soup Kitchen'
+    description 'daily hot soups'
+    short_desc 'short description'
+    association :address, factory: :far_west
+    association :organization, factory: :food_pantry
+  end
 end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -8,4 +8,8 @@ FactoryGirl.define do
   factory :nearby_org, class: Organization do
     name 'Food Stamps'
   end
+
+  factory :food_pantry, class: Organization do
+    name 'Food Pantry'
+  end
 end


### PR DESCRIPTION
Previously, you had to supply the exact organization name to get a match when searching with the "org_name" parameter. Now you can find organizations by only specifying some of the words in the name.

If multiple words are submitted, the search will use an `AND` to find results that match all words. So, given 2 org names, `Peninsula Family Service` and `Peninsula Volunteers`, `api/search?org_name=peninsula service` will only return locations that belong to `Peninsula Family Service`.
