### PR TITLE
Remove Redis dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ rvm:
   - 2.1.1
 addons:
   postgresql: "9.3"
-services:
-  - redis-server
 before_script:
   - psql -c 'create database ohana_api_test;' -U postgres
   - psql -U postgres -q -d ohana_api_test -f db/structure.sql

--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ end
 
 # Geocoding
 gem 'geocoder'
-gem 'redis'
 
 # Format validation for URLs, phone numbers, zipcodes
 gem 'validates_formatting_of', '~> 0.8.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,7 +254,6 @@ GEM
     rainbow (2.0.0)
     rake (10.3.1)
     redcard (1.1.0)
-    redis (3.0.7)
     reek (1.3.7)
       rainbow
       ruby2ruby (~> 2.0.8)
@@ -380,7 +379,6 @@ DEPENDENCIES
   rails (~> 4.0.4)
   rails_12factor
   rails_config
-  redis
   rspec-rails (~> 2.14.2)
   rubocop
   sass-rails (~> 4.0.2)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ You can also try it from the Rails console, mimicking how the API would do it wh
 * Ruby version 2.1.1
 * Rails version 4.0.4
 * Postgres
-* Redis
 * API framework: Grape
 * Testing Frameworks: RSpec, Factory Girl, Capybara
 
@@ -85,24 +84,6 @@ If that doesn't work, try this [tutorial](http://www.moncefbelyamani.com/how-to-
 **Other**
 
 See the Downloads page on postgresql.org for steps to install on other systems: [http://www.postgresql.org/download/](http://www.postgresql.org/download/)
-
-
-#### Redis
-**OS X**
-
-On OS X, the easiest way to install Redis is with Homebrew:
-
-    brew install redis
-
-Follow the Homebrew instructions if you want Redis to start automatically every time you restart your computer. Otherwise launch Redis manually in a separate Terminal tab or window:
-
-    redis-server
-
-[Redis installation instructions using MacPorts](https://github.com/codeforamerica/ohana-api/wiki/Installing-Redis-with-MacPorts-on-OS-X) are available on the wiki.
-
-**Other**
-
-See the Download page on Redis.io for steps to install on other systems: [http://redis.io/download](http://redis.io/download)
 
 ### Clone the app on your local machine:
 

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,16 +1,5 @@
-require 'redis'
-
-if Rails.env.production? || Rails.env.staging?
-  REDIS = Redis.connect(url: ENV['REDISTOGO_URL'])
-elsif Rails.env.test?
-  REDIS = Redis.new(db: 1)
-else
-  REDIS = Redis.new
-end
-
 Geocoder.configure(
   lookup: :google,
-  cache: REDIS,
   always_raise: [
     Geocoder::OverQueryLimitError,
     Geocoder::RequestDenied,

--- a/script/setup_heroku
+++ b/script/setup_heroku
@@ -31,9 +31,6 @@ then
   echo "Installing Postgres"
   heroku addons:add heroku-postgresql --app $herokuApp
 
-  echo "Installing Redis To Go"
-  heroku addons:add redistogo --app $herokuApp
-
   echo "Installing Mandrill by MailChimp"
   heroku addons:add mandrill --app $herokuApp
 

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -6,6 +6,8 @@ FactoryGirl.define do
     description 'Provides jobs training'
     short_desc 'short description'
     accessibility [:tape_braille, :disabled_parking]
+    latitude 37.583939
+    longitude(-122.3715745)
     organization
     address
 
@@ -19,6 +21,8 @@ FactoryGirl.define do
     description 'great books about jobs'
     short_desc 'short description'
     accessibility [:elevator]
+    latitude 37.5808591
+    longitude(-122.343072)
     association :address, factory: :near
     languages %w(spanish Arabic)
     association :organization, factory: :nearby_org
@@ -36,6 +40,8 @@ FactoryGirl.define do
     name 'Belmont Farmers Market'
     description 'yummy food about jobs'
     short_desc 'short description'
+    latitude 37.3180168
+    longitude(-122.2743951)
     association :address, factory: :far_west
     organization
   end
@@ -44,6 +50,8 @@ FactoryGirl.define do
     name 'Belmont Farmers Market'
     description 'yummy food'
     short_desc 'short description'
+    latitude 37.6047797
+    longitude(-122.3984501)
     association :address, factory: :far
     languages %w(spanish Arabic)
     organization
@@ -63,6 +71,8 @@ FactoryGirl.define do
     name 'Soup Kitchen'
     description 'daily hot soups'
     short_desc 'short description'
+    latitude 37.3180168
+    longitude(-122.2743951)
     association :address, factory: :far_west
     association :organization, factory: :food_pantry
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,6 @@ RSpec.configure do |config|
 
   config.after(:each) do
     DatabaseCleaner.clean
-    REDIS.keys.each { |key| REDIS.del key if key.include?('throttle') }
     Warden.test_reset!
   end
 end

--- a/spec/support/geocoder_stubs.rb
+++ b/spec/support/geocoder_stubs.rb
@@ -1,0 +1,107 @@
+Geocoder.configure(:lookup => :test)
+
+Geocoder::Lookup::Test.add_stub(
+  "94403", [
+    {
+      'latitude'     => 37.5349925,
+      'longitude'    => -122.3050823,
+      'address'      => 'San Mateo, CA 94403, USA',
+      'state'        => 'California',
+      'state_code'   => 'CA',
+      'country'      => 'United States',
+      'country_code' => 'US'
+    }
+  ]
+)
+
+Geocoder::Lookup::Test.add_stub(
+  "la honda, ca", [
+    {
+      'latitude'     => 37.3190255,
+      'longitude'    => -122.274227,
+      'address'      => 'La Honda, CA, USA',
+      'state'        => 'California',
+      'state_code'   => 'CA',
+      'country'      => 'United States',
+      'country_code' => 'US'
+    }
+  ]
+)
+
+Geocoder::Lookup::Test.add_stub(
+  "san gregorio, ca", [
+    {
+      'latitude'     => 37.32716509999999,
+      'longitude'    => -122.3866404,
+      'address'      => 'San Gregorio, CA 94019, USA',
+      'state'        => 'California',
+      'state_code'   => 'CA',
+      'country'      => 'United States',
+      'country_code' => 'US'
+    }
+  ]
+)
+
+Geocoder::Lookup::Test.add_stub(
+  "pescadero, ca", [
+    {
+      'latitude'     => 37.2551636,
+      'longitude'    => -122.3830152,
+      'address'      => 'Pescadero, CA, USA',
+      'state'        => 'California',
+      'state_code'   => 'CA',
+      'country'      => 'United States',
+      'country_code' => 'US'
+    }
+  ]
+)
+
+Geocoder::Lookup::Test.add_stub(
+  "Burlingame", [
+    {
+      'latitude'     => 37.5778696,
+      'longitude'    => -122.34809,
+      'address'      => 'Burlingame, CA, USA',
+      'state'        => 'California',
+      'state_code'   => 'CA',
+      'country'      => 'United States',
+      'country_code' => 'US'
+    }
+  ]
+)
+
+Geocoder::Lookup::Test.add_stub(
+  "1236 Broadway, Burlingame, CA 94010", [
+    {
+      'latitude'     => 37.5857936,
+      'longitude'    => -122.3653504,
+      'address'      => '1236 Broadway, Burlingame, CA 94010',
+      'state'        => 'California',
+      'state_code'   => 'CA',
+      'country'      => 'United States',
+      'country_code' => 'US'
+    }
+  ]
+)
+
+Geocoder::Lookup::Test.add_stub(
+  "00000", []
+)
+
+Geocoder::Lookup::Test.add_stub(
+  "94403ab", []
+)
+
+Geocoder::Lookup::Test.set_default_stub(
+  [
+    {
+      'latitude'     => 40.7143528,
+      'longitude'    => -74.0059731,
+      'address'      => 'New York, NY, USA',
+      'state'        => 'New York',
+      'state_code'   => 'NY',
+      'country'      => 'United States',
+      'country_code' => 'US'
+    }
+  ]
+)


### PR DESCRIPTION
Redis was only being used to cache geocoding requests, and is not required to run the app in any environment. It should be up to the user to decide whether or not they want to cache geocoding requests, and which cache store to use.
