### PR TITLE
Refactor text_search method.

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -5,14 +5,7 @@ module Api
       include CustomErrors
 
       def index
-        tables =
-          if params[:org_name].present? && params[:location].present?
-            [:address, :phones]
-          else
-            [:organization, :address, :phones]
-          end
-
-        locations = Location.text_search(params).uniq.page(params[:page]).
+        locations = Location.search(params).uniq.page(params[:page]).
                             per(params[:per_page]).
                             includes(tables)
 
@@ -35,6 +28,16 @@ module Api
 
         render json: nearby, status: 200
         generate_pagination_headers(nearby)
+      end
+
+      private
+
+      def tables
+        if params[:org_name].present? && params[:location].present?
+          [:address, :phones]
+        else
+          [:organization, :address, :phones]
+        end
       end
     end
   end


### PR DESCRIPTION
For scopes that only take one parameter use the simplified method that loops through each parameter and uses the corresponding scope. This means we can remove the parameter presence check from the scopes.

Clean up the controller by moving the `tables` variable to a private method.
