### PR TITLE
Standardized form contact text

### DIFF
--- a/app/views/admin/locations/forms/_phones.html.haml
+++ b/app/views/admin/locations/forms/_phones.html.haml
@@ -6,7 +6,7 @@
       %em
         10 digits only please, in this format: 650-802-7922.
         %br
-        If the phone number belongs to a contact, please move it to the existing contact, or create a new contact.
+        If the phone number belongs to a contact, please move it to the existing contact, or add a contact.
   = f.fields_for :phones do |builder|
     = render 'admin/locations/forms/phone_fields', f: builder
   = link_to_add_fields 'Add a phone number', f, :phones


### PR DESCRIPTION
Made the text on the new contact button and the help text on phone
numbers match.

Resolves #194.
