### PR TITLE
Turn on SSL in production. Closes #41.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Set to :debug to see everything in the log.
   config.log_level = :info


### PR DESCRIPTION
Heroku apps are SSL-enabled by default, and to take advantage of that, all we need to do is turn on SSL in the Rails production config file.

To use SSL with a custom domain, read the following section in the Wiki:

https://github.com/codeforamerica/ohana-api/wiki/How-to-deploy-the-Ohana-API-to-your-Heroku-account#using-a-custom-domain-name-and-ssl-configuration
