### PR TITLE
Use Select2 for service areas field.

### DIFF
--- a/app/assets/javascripts/admin/service_areas.js
+++ b/app/assets/javascripts/admin/service_areas.js
@@ -1,0 +1,5 @@
+$(document).ready(function() {
+  $('#service_service_areas').select2({
+    placeholder: 'Select one or more service areas'
+  });
+});

--- a/app/views/admin/services/forms/_service_area_fields.html.haml
+++ b/app/views/admin/services/forms/_service_area_fields.html.haml
@@ -1,4 +1,0 @@
-= field_set_tag do
-  = text_field_tag 'service[service_areas][]', '', class: 'form-control'
-  = link_to 'Delete this service area permanently', '#', class: 'btn btn-danger delete_attribute'
-  %hr

--- a/app/views/admin/services/forms/_service_areas.html.haml
+++ b/app/views/admin/services/forms/_service_areas.html.haml
@@ -4,16 +4,6 @@
       Service Areas
     %p.desc
       What city or county does the location serve?
-      %em
-        Can either be city names or county names. Each word must be capitalized.
 
-  - if @service.service_areas.present?
-    - @service.service_areas.each_with_index do |service_area, i|
-      = field_set_tag do
-        .row
-          %div{ class: "col-sm-6 #{error_class_for(@service, :service_areas, service_area)}" }
-            = text_field_tag 'service[service_areas][]', service_area, class: 'form-control', id: "service_service_areas_#{i}"
-        = link_to 'Delete this service area permanently', '#', class: 'btn btn-danger delete_attribute'
-        %hr
-  = link_to_add_array_fields 'Add a new service area', :services, :service_area
-
+  = field_set_tag do
+    = f.select :service_areas, SETTINGS.try(:[], :valid_service_areas), {}, multiple: true, class: 'form-control'

--- a/config/settings.example.yml
+++ b/config/settings.example.yml
@@ -211,8 +211,8 @@ tld_length: 2
 ###########################################
 test:
   valid_service_areas:
-  - Belmont
   - Atherton
+  - Belmont
 
   bounds: [[37.1074, -122.521], [37.7084, -122.085]]
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -211,8 +211,8 @@ tld_length: 2
 ###########################################
 test:
   valid_service_areas:
-  - Belmont
   - Atherton
+  - Belmont
 
   bounds: [[37.1074, -122.521], [37.7084, -122.085]]
 

--- a/spec/features/admin/services/create_service_spec.rb
+++ b/spec/features/admin/services/create_service_spec.rb
@@ -99,12 +99,11 @@ feature 'Create a new service' do
   scenario 'when adding a service area', :js do
     fill_in 'service_name', with: 'New VRS Services service'
     fill_in 'service_description', with: 'new description'
-    click_link 'Add a new service area'
-    fill_in find(:xpath, "//input[@name='service[service_areas][]']")[:id], with: 'Belmont'
+    select2('Belmont', 'service_service_areas', multiple: true)
     click_button 'Create service'
     click_link 'New VRS Services service'
 
-    expect(find_field('service[service_areas][]').value).to eq 'Belmont'
+    expect(find(:css, 'select#service_service_areas').value).to eq(['Belmont'])
   end
 
   scenario 'when adding categories', :js do


### PR DESCRIPTION
Since the list of valid service areas is defined in settings.yml, it
should be used to populate the choices in the select field in the admin
interface. That way, it won’t be possible to submit an invalid value,
and users won’t have to guess what to enter.
