### PR TITLE
Use Select2 to update service keywords inline.

### DIFF
--- a/app/assets/javascripts/admin/keywords.js
+++ b/app/assets/javascripts/admin/keywords.js
@@ -1,0 +1,6 @@
+$(document).ready(function() {
+  $("#service_keywords").select2({
+    tags: [''],
+    tokenSeparators: [',']
+  });
+});

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -20,6 +20,9 @@ class Admin
       @location = Location.find(params[:location_id])
       @oe_ids = @service.categories.pluck(:oe_id)
 
+      keywords = params[:service][:keywords]
+      params[:service][:keywords] = keywords.shift.split(',')
+
       respond_to do |format|
         if @service.update(params[:service])
           format.html do
@@ -46,6 +49,9 @@ class Admin
     end
 
     def create
+      keywords = params[:service][:keywords]
+      params[:service][:keywords] = keywords.shift.split(',')
+
       @location = Location.find(params[:location_id])
       @service = @location.services.new(params[:service])
       @oe_ids = []

--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -15,7 +15,7 @@ module Api
       end
 
       def show
-        location = Location.find(params[:id])
+        location = Location.includes(services: :categories).find(params[:id])
         render json: location, status: 200
         expires_in ENV['EXPIRES_IN'].to_i.minutes, public: true
       end

--- a/app/controllers/api/v1/services_controller.rb
+++ b/app/controllers/api/v1/services_controller.rb
@@ -14,8 +14,7 @@ module Api
 
       def update
         service = Service.find(params[:id])
-        location = Location.find(params[:location_id])
-        service.update!(params.merge(location_id: location.id))
+        service.update!(params)
         render json: service, status: 200
       end
 

--- a/app/views/admin/services/forms/_keyword_fields.html.haml
+++ b/app/views/admin/services/forms/_keyword_fields.html.haml
@@ -1,6 +1,0 @@
-= field_set_tag do
-  .row
-    .col-md-6
-      = text_field_tag 'service[keywords][]', '', class: 'form-control'
-  = link_to 'Delete this keyword permanently', '#', class: 'btn btn-danger delete_attribute'
-  %hr

--- a/app/views/admin/services/forms/_keywords.html.haml
+++ b/app/views/admin/services/forms/_keywords.html.haml
@@ -3,15 +3,7 @@
     %strong
       Keywords
     %p.desc
-      What search terms does this location's services fall under?
+      The best way to ensure a service appears in search results is to write a detailed and accurate service description. If certain words or phrases cannot be part of the description, such as common misspellings, then the keywords field is where you can add them.
 
-  - if @service.keywords.present?
-    - @service.keywords.each_with_index do |keyword, i|
-      = field_set_tag do
-        .row
-          .col-md-6
-            = text_field_tag 'service[keywords][]', keyword, class: 'form-control', id: "service_keywords_#{i}"
-        = link_to 'Delete this keyword permanently', '#', class: 'btn btn-danger delete_attribute'
-        %hr
-  = link_to_add_array_fields 'Add a new keyword', :services, :keyword
-
+  = field_set_tag do
+    = text_field_tag 'service[keywords][]', @service.keywords.join(','), id: 'service_keywords', class: 'form-control'

--- a/config/initializers/auto_strip_attributes.rb
+++ b/config/initializers/auto_strip_attributes.rb
@@ -2,7 +2,7 @@ AutoStripAttributes::Config.setup do
   set_filter reject_blank: false do |value|
     if value.respond_to?(:strip)
       value
-    elsif value.present?
+    elsif !value.nil?
       value.map(&:squish).reject(&:blank?).uniq
     end
   end

--- a/spec/features/admin/services/create_service_spec.rb
+++ b/spec/features/admin/services/create_service_spec.rb
@@ -85,15 +85,16 @@ feature 'Create a new service' do
     expect(find_field('service[urls][]').value).to eq 'http://ruby.com'
   end
 
-  scenario 'when adding a keyword', :js do
+  scenario 'when adding multiple keywords', :js do
     fill_in 'service_name', with: 'New VRS Services service'
     fill_in 'service_description', with: 'new description'
-    click_link 'Add a new keyword'
-    fill_in find(:xpath, "//input[@name='service[keywords][]']")[:id], with: 'ruby'
+    select2('first', 'service_keywords', multiple: true, tag: true)
+    select2('second', 'service_keywords', multiple: true, tag: true)
     click_button 'Create service'
     click_link 'New VRS Services service'
 
-    expect(find_field('service[keywords][]').value).to eq 'ruby'
+    service = Service.find_by_name('New VRS Services service')
+    expect(service.keywords).to eq %w(first second)
   end
 
   scenario 'when adding a service area', :js do

--- a/spec/features/admin/services/update_keywords_spec.rb
+++ b/spec/features/admin/services/update_keywords_spec.rb
@@ -2,44 +2,39 @@ require 'rails_helper'
 
 feature 'Update keywords' do
   background do
-    create_service
+    location = create(:location)
+    @service = location.services.create!(
+      name: 'Literacy Program', description: 'learn to read')
     login_super_admin
-  end
-
-  scenario 'when no keywords exist' do
-    @service.update!(keywords: [])
     visit '/admin/locations/vrs-services'
     click_link 'Literacy Program'
-    expect(page).to have_no_xpath("//input[@name='service[keywords][]']")
   end
 
-  scenario 'by adding 2 new keywords', :js do
-    @service.update!(keywords: [])
-    visit '/admin/locations/vrs-services'
-    click_link 'Literacy Program'
-    add_two_keywords
-    expect(find_field('service_keywords_0').value).to eq 'homeless'
-    delete_all_keywords
-    expect(page).to have_no_xpath("//input[@name='service[keywords][]']")
+  scenario 'when no keywords exist', :js do
+    expect(page).to have_no_css('.select2-search-choice-close')
   end
 
-  scenario 'with 2 keywords but one is empty', :js do
-    @service.update!(keywords: ['education'])
-    visit '/admin/locations/vrs-services'
-    click_link 'Literacy Program'
-    click_link 'Add a new keyword'
+  scenario 'with one keyword', :js do
+    select2('ligal', 'service_keywords', multiple: true, tag: true)
     click_button 'Save changes'
-    total_keywords = all(:xpath, "//input[@name='service[keywords][]']")
-    expect(total_keywords.length).to eq 1
+    expect(@service.reload.keywords).to eq ['ligal']
   end
 
-  scenario 'with valid keyword' do
-    @service.update!(keywords: ['health'])
+  scenario 'with two keywords', :js do
+    select2('first', 'service_keywords', multiple: true, tag: true)
+    select2('second', 'service_keywords', multiple: true, tag: true)
+    click_button 'Save changes'
+    expect(@service.reload.keywords).to eq %w(first second)
+  end
+
+  scenario 'removing a keyword', :js do
+    @service.update!(keywords: %w(resume computer))
     visit '/admin/locations/vrs-services'
     click_link 'Literacy Program'
-    fill_in 'service_keywords_0', with: 'food pantry'
+    within '#s2id_service_keywords' do
+      first('.select2-search-choice-close').click
+    end
     click_button 'Save changes'
-    expect(find_field('service_keywords_0').value).
-      to eq 'food pantry'
+    expect(@service.reload.keywords).to eq ['computer']
   end
 end

--- a/spec/features/admin/services/update_service_areas_spec.rb
+++ b/spec/features/admin/services/update_service_areas_spec.rb
@@ -2,13 +2,15 @@ require 'rails_helper'
 
 feature 'Update service areas' do
   background do
-    create_service
+    location = create(:location)
+    @service = location.services.
+      create!(attributes_for(:service).merge(keywords: []))
     login_super_admin
     visit '/admin/locations/vrs-services'
     click_link 'Literacy Program'
   end
 
-  scenario 'when no service areas exist' do
+  scenario 'when no service areas exist', :js do
     expect(page).to have_no_css('.select2-search-choice-close')
   end
 
@@ -29,7 +31,9 @@ feature 'Update service areas' do
     @service.update!(service_areas: %w(Atherton Belmont))
     visit '/admin/locations/vrs-services'
     click_link 'Literacy Program'
-    first('.select2-search-choice-close').click
+    within '#s2id_service_service_areas' do
+      first('.select2-search-choice-close').click
+    end
     click_button 'Save changes'
     expect(@service.reload.service_areas).to eq ['Belmont']
   end

--- a/spec/support/features/form_helpers.rb
+++ b/spec/support/features/form_helpers.rb
@@ -172,18 +172,37 @@ module Features
     end
 
     def select2(value, id, options = {})
-      select2_container = first("#s2id_#{id}")
+      set_select2_value(value, options[:multiple], first("#s2id_#{id}"))
 
-      if options[:multiple] == true
-        select2_container.find('.select2-choices').click
-      else
-        select2_container.find('.select2-choice').click
-      end
-
-      find(:xpath, '//body').find('input.select2-input').set(value)
       page.execute_script(%|$('input.select2-input:visible').keyup();|)
-      drop_container = '.select2-results'
-      find(:xpath, '//body').find("#{drop_container} li", text: value).click
+
+      find(:xpath, '//body').
+        find("#{drop_container(options[:tag])} li", text: value).click
+    end
+
+    def drop_container(tag_option)
+      return '.select2-results' unless tag_option == true
+      '.select2-drop'
+    end
+
+    def set_select2_value(value, multiple_option, container)
+      if multiple_option == true
+        set_multiple_select2_value(value, container)
+      else
+        set_single_select2_value(value, container)
+      end
+    end
+
+    def set_multiple_select2_value(value, container)
+      container.find('.select2-choices').click
+      within container do
+        find('input.select2-input').set(value)
+      end
+    end
+
+    def set_single_select2_value(value, container)
+      container.find('.select2-choice').click
+      find(:xpath, '//body').find('input.select2-input').set(value)
     end
 
     def add_two_keywords


### PR DESCRIPTION
Instead of cluttering the interface with a bunch of keyword fields laid
out vertically, and with each having a “delete this keyword” button, we
can use Select2 to add and remove keywords inside a single input field.
