### PR TITLE
Remove unused custom pagination HTTP headers.

### DIFF
--- a/app/controllers/concerns/pagination_headers.rb
+++ b/app/controllers/concerns/pagination_headers.rb
@@ -14,10 +14,6 @@ module PaginationHeaders
 
     response.headers['Link'] = links.join(', ') unless links.blank?
     response.headers['X-Total-Count'] = "#{coll.total_count}"
-    response.headers['X-Total-Pages'] = "#{coll.total_pages}"
-    response.headers['X-Current-Page'] = "#{coll.current_page}" unless coll.empty?
-    response.headers['X-Next-Page'] = "#{coll.next_page}" unless coll.next_page.nil?
-    response.headers['X-Previous-Page'] = "#{pages[:prev]}" unless coll.prev_page.nil?
   end
 
   def url

--- a/spec/api/cors_spec.rb
+++ b/spec/api/cors_spec.rb
@@ -32,7 +32,7 @@ describe 'CORS Preflight Request via OPTIONS HTTP method' do
       expect(headers['Access-Control-Allow-Credentials']).to eq('true')
     end
 
-    it 'returns an empty Access-Control-Expose-Headers header' do
+    it 'only exposes the Link and X-Total-Count headers' do
       expect(headers['Access-Control-Expose-Headers']).to eq('Link, X-Total-Count')
     end
 
@@ -127,7 +127,7 @@ describe 'CORS REQUESTS - POST and GET' do
       expect(headers['Access-Control-Allow-Credentials']).to eq('true')
     end
 
-    it 'exposes the Link and X-Total-Count headers' do
+    it 'only exposes the Link and X-Total-Count headers' do
       expect(headers['Access-Control-Expose-Headers']).to eq('Link, X-Total-Count')
     end
   end

--- a/spec/api/pagination_headers_spec.rb
+++ b/spec/api/pagination_headers_spec.rb
@@ -38,18 +38,6 @@ describe 'Pagination Headers' do
       expect(json.length).to eq(1)
       expect(headers['X-Total-Count']).to eq('2')
     end
-
-    it 'returns an X-Total-Pages header' do
-      expect(response.status).to eq 200
-      expect(json.length).to eq(1)
-      expect(headers['X-Total-Pages']).to eq('2')
-    end
-
-    it 'returns pagination headers' do
-      expect(headers['X-Current-Page']).to eq '1'
-      expect(headers['X-Next-Page']).to eq '2'
-      expect(headers['X-Previous-Page']).to be_nil
-    end
   end
 
   context 'when on page 2 of 2' do
@@ -74,12 +62,6 @@ describe 'Pagination Headers' do
         "<#{@prefix}?keyword=jobs&page=1" \
         "&per_page=1>; rel=\"prev\""
       )
-    end
-
-    it 'returns pagination headers' do
-      expect(headers['X-Current-Page']).to eq '2'
-      expect(headers['X-Next-Page']).to be_nil
-      expect(headers['X-Previous-Page']).to eq('1')
     end
   end
 
@@ -111,12 +93,6 @@ describe 'Pagination Headers' do
         "&per_page=1>; rel=\"next\""
       )
     end
-
-    it 'returns pagination headers' do
-      expect(headers['X-Current-Page']).to eq '2'
-      expect(headers['X-Next-Page']).to eq '3'
-      expect(headers['X-Previous-Page']).to eq '1'
-    end
   end
 
   context 'when on page higher than max' do
@@ -141,13 +117,6 @@ describe 'Pagination Headers' do
         "<#{@prefix}?keyword=vrs&page=1>; rel=\"prev\", " \
         "<#{@prefix}?keyword=vrs&page=1>; rel=\"last\""
       )
-    end
-
-    it 'returns pagination headers' do
-      expect(headers.keys).not_to include 'X-Current-Page'
-      expect(headers.keys).not_to include 'X-Next-Page'
-      expect(headers['X-Previous-Page']).to eq '1'
-      expect(headers['X-Total-Pages']).to eq('1')
     end
   end
 


### PR DESCRIPTION
Only `Link` and `X-Total-Count` are useful for clients such as Ohana
Web Search. Originally, the others (such as `X-Total-Pages` and
`X-Current-Page`) were added to help implement pagination in Ohana Web
Search, but we realized that we could just use existing tools such as
the `kaminari` gem to do the pagination for us.
