### PR TITLE
Optimize nearby endpoint.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,8 @@ Style/GuardClause:
 
 Rails/HasAndBelongsToMany:
   Enabled: false
+
+Style/AndOr:
+  # Whether `and` and `or` are banned only in conditionals (conditionals)
+  # or completely (always).
+  EnforcedStyle: conditionals

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -16,18 +16,16 @@ module Api
 
       def nearby
         location = Location.find(params[:location_id])
+
+        render json: [] and return if location.coordinates.blank?
+
         radius = Location.validated_radius(params[:radius], 0.5)
 
-        nearby =
-          if location.coordinates.present?
-            location.nearbys(radius).
-                    page(params[:page]).per(params[:per_page]).
-                    includes(:organization, :address, :phones)
-          else
-            Location.none.page(params[:page]).per(params[:per_page])
-          end
+        nearby = location.nearbys(radius).
+                         page(params[:page]).per(params[:per_page]).
+                         includes(:address)
 
-        render json: nearby, status: 200
+        render json: nearby, each_serializer: NearbySerializer, status: 200
         generate_pagination_headers(nearby)
       end
 

--- a/app/serializers/nearby_serializer.rb
+++ b/app/serializers/nearby_serializer.rb
@@ -1,0 +1,5 @@
+class NearbySerializer < ActiveModel::Serializer
+  attributes :id, :alternate_name, :latitude, :longitude, :name, :slug
+
+  has_one :address
+end

--- a/spec/api/nearby_spec.rb
+++ b/spec/api/nearby_spec.rb
@@ -16,6 +16,12 @@ describe "GET 'nearby'" do
     expect(json.first['name']).to eq('Belmont Farmers Market')
   end
 
+  it 'returns a summarized JSON representation' do
+    get api_location_nearby_url(@loc, radius: 2, subdomain: ENV['API_SUBDOMAIN'])
+    expect(json.first.keys).
+      to eq %w(id alternate_name latitude longitude name slug address)
+  end
+
   context 'with no radius' do
     it 'displays nearby locations within 0.5 miles' do
       get api_location_nearby_url(@loc, subdomain: ENV['API_SUBDOMAIN'])


### PR DESCRIPTION
The most common way the nearby endpoint would be used is to display
locations near the one currently being visited on a map. A client would
only need a few location attributes to make use of this endpoint, such
as the name, alternate name, latitude, longitude, address, and slug.

By creating a special serializer that only returns a few attributes, we
improve the performance of the nearby endpoint.
