### PR TITLE
Expose weekday as integer.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 bundler_args: --without assets:development:production
 language: ruby
 rvm:
-  - 2.1.2
+  - 2.1.3
 addons:
   postgresql: "9.3"
 before_script:

--- a/app/serializers/regular_schedule_serializer.rb
+++ b/app/serializers/regular_schedule_serializer.rb
@@ -1,7 +1,3 @@
 class RegularScheduleSerializer < ActiveModel::Serializer
   attributes :weekday, :opens_at, :closes_at
-
-  def weekday
-    Admin::FormHelper::WEEKDAYS[object.weekday - 1]
-  end
 end

--- a/spec/api/get_location_spec.rb
+++ b/spec/api/get_location_spec.rb
@@ -116,7 +116,7 @@ describe 'GET /locations/:id' do
           'phones'             => [],
           'regular_schedules'  => [
             {
-              'weekday'   => 'Monday',
+              'weekday'   => 1,
               'opens_at'  => '2000-01-01T09:30:00.000Z',
               'closes_at' => '2000-01-01T17:00:00.000Z'
             }
@@ -205,7 +205,7 @@ describe 'GET /locations/:id' do
 
       serialized_regular_schedule =
         {
-          'weekday'   => 'Monday',
+          'weekday'   => 1,
           'opens_at'  => '2000-01-01T09:30:00.000Z',
           'closes_at' => '2000-01-01T17:00:00.000Z'
         }


### PR DESCRIPTION
This will allow clients to format and display the weekday name as they
please. The recommended way for a Rails client such as Ohana Web Search
would be to add an entry to the I18n file, such as `en.yml`, that would
look like this:

```
weekdays:
  - Monday
  - Tuesday
  - Wednesday
  - Thursday
  - Friday
  - Saturday
  - Sunday
```

You can then access the weekday String by doing this:
`I18n.t(‘weekdays’)[weekday - 1]`

Closes #273.
