### PR TITLE
Ignore CSV files that are not required.

### DIFF
--- a/lib/entity_importer.rb
+++ b/lib/entity_importer.rb
@@ -6,6 +6,21 @@ class EntityImporter < Struct.new(:content)
     new(content).tap(&:import)
   end
 
+  def self.check_and_import_file(path)
+    file = FileChecker.new(path)
+
+    return process_import(path) if file.available? && file.entries?
+
+    if file.required_but_missing? || file.required_but_empty?
+      fail "#{file.filename} is required but is missing or empty"
+    end
+  end
+
+  def self.process_import(path)
+    importer = import_file(path)
+    importer.errors.each { |e| Kernel.puts(e) } unless importer.valid?
+  end
+
   def valid_headers?
     missing_headers.empty?
   end

--- a/lib/file_checker.rb
+++ b/lib/file_checker.rb
@@ -1,0 +1,52 @@
+require 'csv'
+
+class FileChecker
+  attr_reader :path
+
+  def initialize(path)
+    @path = path
+  end
+
+  def filename
+    path.to_s.split('/').last
+  end
+
+  def available?
+    File.file?(path)
+  end
+
+  def missing?
+    !available?
+  end
+
+  def entries?
+    csv_entries.present?
+  end
+
+  def required_but_missing?
+    required? && !available?
+  end
+
+  def required_but_empty?
+    required? && !entries?
+  end
+
+  protected
+
+  def required?
+    required_files.include? filename
+  end
+
+  def content
+    File.read(path)
+  end
+
+  def csv_entries
+    @csv_entries ||= CSV.new(content, headers: true).entries
+  end
+
+  def required_files
+    %w(organizations.csv locations.csv addresses.csv services.csv phones.csv
+       regular_schedules.csv holiday_schedules.csv)
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -6,16 +6,14 @@ namespace :import do
   task :organizations, [:path] => :environment do |_, args|
     Kernel.puts('Importing your organizations...')
     args.with_defaults(path: Rails.root.join('data/organizations.csv'))
-    importer = OrganizationImporter.import_file(args[:path])
-    importer.errors.each { |e| Kernel.puts(e) } unless importer.valid?
+    OrganizationImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports programs'
   task :programs, [:path] => :environment do |_, args|
     Kernel.puts('Importing your programs...')
     args.with_defaults(path: Rails.root.join('data/programs.csv'))
-    importer = ProgramImporter.import_file(args[:path])
-    importer.errors.each { |e| Kernel.puts(e) } unless importer.valid?
+    ProgramImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports locations'
@@ -25,55 +23,48 @@ namespace :import do
       path: Rails.root.join('data/locations.csv'),
       addresses_path: Rails.root.join('data/addresses.csv')
     )
-    importer = LocationImporter.import_file(args[:path], args[:addresses_path])
-    importer.errors.each { |e| Kernel.puts(e) } unless importer.valid?
+    LocationImporter.check_and_import_file(args[:path], args[:addresses_path])
   end
 
   desc 'Imports services'
   task :services, [:path] => :environment do |_, args|
     Kernel.puts('Importing your services...')
     args.with_defaults(path: Rails.root.join('data/services.csv'))
-    importer = ServiceImporter.import_file(args[:path])
-    importer.errors.each { |e| Kernel.puts(e) } unless importer.valid?
+    ServiceImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports mail addresses'
   task :mail_addresses, [:path] => :environment do |_, args|
     Kernel.puts('Importing your mail addresses...')
     args.with_defaults(path: Rails.root.join('data/mail_addresses.csv'))
-    importer = MailAddressImporter.import_file(args[:path])
-    importer.errors.each { |e| Kernel.puts(e) } unless importer.valid?
+    MailAddressImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports contacts'
   task :contacts, [:path] => :environment do |_, args|
     Kernel.puts('Importing your contacts...')
     args.with_defaults(path: Rails.root.join('data/contacts.csv'))
-    importer = ContactImporter.import_file(args[:path])
-    importer.errors.each { |e| Kernel.puts(e) } unless importer.valid?
+    ContactImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports phones'
   task :phones, [:path] => :environment do |_, args|
     Kernel.puts('Importing your phones...')
     args.with_defaults(path: Rails.root.join('data/phones.csv'))
-    importer = PhoneImporter.import_file(args[:path])
-    importer.errors.each { |e| Kernel.puts(e) } unless importer.valid?
+    PhoneImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports regular_schedules'
   task :regular_schedules, [:path] => :environment do |_, args|
     Kernel.puts('Importing your regular_schedules...')
     args.with_defaults(path: Rails.root.join('data/regular_schedules.csv'))
-    importer = RegularScheduleImporter.import_file(args[:path])
-    importer.errors.each { |e| Kernel.puts(e) } unless importer.valid?
+    RegularScheduleImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports holiday_schedules'
   task :holiday_schedules, [:path] => :environment do |_, args|
     Kernel.puts('Importing your holiday_schedules...')
     args.with_defaults(path: Rails.root.join('data/holiday_schedules.csv'))
-    importer = HolidayScheduleImporter.import_file(args[:path])
-    importer.errors.each { |e| Kernel.puts(e) } unless importer.valid?
+    HolidayScheduleImporter.check_and_import_file(args[:path])
   end
 end

--- a/spec/lib/contact_importer_spec.rb
+++ b/spec/lib/contact_importer_spec.rb
@@ -160,12 +160,12 @@ describe ContactImporter do
     end
   end
 
-  describe '.import_file' do
+  describe '.check_and_import_file' do
     context 'with valid data' do
       it 'creates a contact' do
         expect do
           path = Rails.root.join('spec/support/fixtures/valid_location_contact.csv')
-          ContactImporter.import_file(path)
+          ContactImporter.check_and_import_file(path)
         end.to change(Contact, :count)
       end
     end
@@ -174,8 +174,26 @@ describe ContactImporter do
       it 'does not create a contact' do
         expect do
           path = Rails.root.join('spec/support/fixtures/invalid_contact.csv')
-          ContactImporter.import_file(path)
+          ContactImporter.check_and_import_file(path)
         end.not_to change(Contact, :count)
+      end
+    end
+
+    context 'when file is missing but not required' do
+      it 'does not raise an error' do
+        expect do
+          path = Rails.root.join('spec/support/data/contacts.csv')
+          ContactImporter.check_and_import_file(path)
+        end.not_to raise_error
+      end
+    end
+
+    context 'when file is empty but not required' do
+      it 'does not raise an error' do
+        expect do
+          path = Rails.root.join('spec/support/fixtures/contacts.csv')
+          ContactImporter.check_and_import_file(path)
+        end.not_to raise_error
       end
     end
   end

--- a/spec/lib/holiday_schedule_importer_spec.rb
+++ b/spec/lib/holiday_schedule_importer_spec.rb
@@ -184,12 +184,12 @@ describe HolidayScheduleImporter do
     end
   end
 
-  describe '.import_file' do
+  describe '.check_and_import_file' do
     context 'with valid data' do
       it 'creates a holiday_schedule' do
         expect do
           path = Rails.root.join('spec/support/fixtures/valid_location_holiday_schedule.csv')
-          HolidayScheduleImporter.import_file(path)
+          HolidayScheduleImporter.check_and_import_file(path)
         end.to change(HolidaySchedule, :count)
       end
     end
@@ -198,8 +198,26 @@ describe HolidayScheduleImporter do
       it 'does not create a holiday_schedule' do
         expect do
           path = Rails.root.join('spec/support/fixtures/invalid_holiday_schedule.csv')
-          HolidayScheduleImporter.import_file(path)
+          HolidayScheduleImporter.check_and_import_file(path)
         end.not_to change(HolidaySchedule, :count)
+      end
+    end
+
+    context 'when file is missing but required' do
+      it 'raises an error' do
+        path = Rails.root.join('spec/support/data/holiday_schedules.csv')
+        expect do
+          HolidayScheduleImporter.check_and_import_file(path)
+        end.to raise_error(/missing or empty/)
+      end
+    end
+
+    context 'when file is empty and required' do
+      it 'raises an error' do
+        expect do
+          path = Rails.root.join('spec/support/fixtures/holiday_schedules.csv')
+          HolidayScheduleImporter.check_and_import_file(path)
+        end.to raise_error(/missing or empty/)
       end
     end
   end

--- a/spec/lib/location_importer_spec.rb
+++ b/spec/lib/location_importer_spec.rb
@@ -159,13 +159,13 @@ describe LocationImporter do
     end
   end
 
-  describe '.import_file' do
+  describe '.check_and_import_file' do
     context 'with valid data' do
       it 'creates a location' do
         expect do
           path = Rails.root.join('spec/support/fixtures/valid_location.csv')
           address_path = Rails.root.join('spec/support/fixtures/valid_address.csv')
-          LocationImporter.import_file(path, address_path)
+          LocationImporter.check_and_import_file(path, address_path)
         end.to change(Location, :count)
       end
     end
@@ -175,7 +175,7 @@ describe LocationImporter do
         expect do
           path = Rails.root.join('spec/support/fixtures/invalid_location.csv')
           address_path = Rails.root.join('spec/support/fixtures/invalid_address.csv')
-          LocationImporter.import_file(path, address_path)
+          LocationImporter.check_and_import_file(path, address_path)
         end.not_to change(Location, :count)
       end
     end
@@ -185,8 +185,74 @@ describe LocationImporter do
         expect do
           path = Rails.root.join('spec/support/fixtures/valid_location.csv')
           address_path = Rails.root.join('spec/support/fixtures/invalid_address.csv')
-          LocationImporter.import_file(path, address_path)
+          LocationImporter.check_and_import_file(path, address_path)
         end.not_to change(Location, :count)
+      end
+    end
+
+    context 'when address is missing' do
+      it 'raises an error' do
+        path = Rails.root.join('spec/support/fixtures/valid_location.csv')
+        address_path = Rails.root.join('spec/support/data/addresses.csv')
+
+        expect do
+          LocationImporter.check_and_import_file(path, address_path)
+        end.to raise_error(/missing or empty/)
+      end
+    end
+
+    context 'when address is empty' do
+      it 'raises an error' do
+        path = Rails.root.join('spec/support/fixtures/valid_location.csv')
+        address_path = Rails.root.join('spec/support/fixtures/addresses.csv')
+
+        expect do
+          LocationImporter.check_and_import_file(path, address_path)
+        end.to raise_error(/missing or empty/)
+      end
+    end
+
+    context 'when location is missing' do
+      it 'raises an error' do
+        path = Rails.root.join('spec/support/data/locations.csv')
+        address_path = Rails.root.join('spec/support/data/valid_address.csv')
+
+        expect do
+          LocationImporter.check_and_import_file(path, address_path)
+        end.to raise_error(/missing or empty/)
+      end
+    end
+
+    context 'when location is empty' do
+      it 'raises an error' do
+        path = Rails.root.join('spec/support/fixtures/locations.csv')
+        address_path = Rails.root.join('spec/support/fixtures/valid_address.csv')
+
+        expect do
+          LocationImporter.check_and_import_file(path, address_path)
+        end.to raise_error(/missing or empty/)
+      end
+    end
+
+    context 'when both are missing' do
+      it 'raises an error' do
+        path = Rails.root.join('spec/support/data/locations.csv')
+        address_path = Rails.root.join('spec/support/data/addresses.csv')
+
+        expect do
+          LocationImporter.check_and_import_file(path, address_path)
+        end.to raise_error(/missing or empty/)
+      end
+    end
+
+    context 'when both are empty' do
+      it 'raises an error' do
+        path = Rails.root.join('spec/support/fixtures/locations.csv')
+        address_path = Rails.root.join('spec/support/fixtures/addresses.csv')
+
+        expect do
+          LocationImporter.check_and_import_file(path, address_path)
+        end.to raise_error(/missing or empty/)
       end
     end
   end

--- a/spec/lib/mail_address_importer_spec.rb
+++ b/spec/lib/mail_address_importer_spec.rb
@@ -131,12 +131,12 @@ describe MailAddressImporter do
     end
   end
 
-  describe '.import_file' do
+  describe '.check_and_import_file' do
     context 'with valid data' do
       it 'creates a mail_address' do
         expect do
           path = Rails.root.join('spec/support/fixtures/valid_mail_address.csv')
-          MailAddressImporter.import_file(path)
+          MailAddressImporter.check_and_import_file(path)
         end.to change(MailAddress, :count)
       end
     end
@@ -145,8 +145,26 @@ describe MailAddressImporter do
       it 'does not create a mail_address' do
         expect do
           path = Rails.root.join('spec/support/fixtures/invalid_mail_address.csv')
-          MailAddressImporter.import_file(path)
+          MailAddressImporter.check_and_import_file(path)
         end.not_to change(MailAddress, :count)
+      end
+    end
+
+    context 'when file is missing but not required' do
+      it 'does not raise an error' do
+        expect do
+          path = Rails.root.join('spec/support/data/mail_addresses.csv')
+          MailAddressImporter.check_and_import_file(path)
+        end.not_to raise_error
+      end
+    end
+
+    context 'when file is empty but not required' do
+      it 'does not raise an error' do
+        expect do
+          path = Rails.root.join('spec/support/fixtures/mail_addresses.csv')
+          MailAddressImporter.check_and_import_file(path)
+        end.not_to raise_error
       end
     end
   end

--- a/spec/lib/organization_importer_spec.rb
+++ b/spec/lib/organization_importer_spec.rb
@@ -152,22 +152,40 @@ describe OrganizationImporter do
     end
   end
 
-  describe '.import_file' do
+  describe '.check_and_import_file' do
     context 'with valid data' do
-      it 'creates a org' do
+      it 'creates an org' do
         expect do
           path = Rails.root.join('spec/support/fixtures/valid_org.csv')
-          OrganizationImporter.import_file(path)
+          OrganizationImporter.check_and_import_file(path)
         end.to change(Organization, :count)
       end
     end
 
     context 'with invalid data' do
-      it 'does not create a org' do
+      it 'does not create an org' do
         expect do
           path = Rails.root.join('spec/support/fixtures/invalid_org.csv')
-          OrganizationImporter.import_file(path)
+          OrganizationImporter.check_and_import_file(path)
         end.not_to change(Organization, :count)
+      end
+    end
+
+    context 'when file is missing but required' do
+      it 'raises an error' do
+        expect do
+          path = Rails.root.join('spec/support/data/organizations.csv')
+          OrganizationImporter.check_and_import_file(path)
+        end.to raise_error(/missing or empty/)
+      end
+    end
+
+    context 'when file is empty and required' do
+      it 'raises an error' do
+        expect do
+          path = Rails.root.join('spec/support/fixtures/organizations.csv')
+          OrganizationImporter.check_and_import_file(path)
+        end.to raise_error(/missing or empty/)
       end
     end
   end

--- a/spec/lib/phone_importer_spec.rb
+++ b/spec/lib/phone_importer_spec.rb
@@ -180,12 +180,12 @@ describe PhoneImporter do
     end
   end
 
-  describe '.import_file' do
+  describe '.check_and_import_file' do
     context 'with valid data' do
       it 'creates a phone' do
         expect do
           path = Rails.root.join('spec/support/fixtures/valid_location_phone.csv')
-          PhoneImporter.import_file(path)
+          PhoneImporter.check_and_import_file(path)
         end.to change(Phone, :count)
       end
     end
@@ -194,8 +194,26 @@ describe PhoneImporter do
       it 'does not create a phone' do
         expect do
           path = Rails.root.join('spec/support/fixtures/invalid_phone.csv')
-          PhoneImporter.import_file(path)
+          PhoneImporter.check_and_import_file(path)
         end.not_to change(Phone, :count)
+      end
+    end
+
+    context 'when file is missing but required' do
+      it 'raises an error' do
+        expect do
+          path = Rails.root.join('spec/support/data/phones.csv')
+          PhoneImporter.check_and_import_file(path)
+        end.to raise_error(/missing or empty/)
+      end
+    end
+
+    context 'when file is empty and required' do
+      it 'raises an error' do
+        expect do
+          path = Rails.root.join('spec/support/fixtures/phones.csv')
+          PhoneImporter.check_and_import_file(path)
+        end.to raise_error(/missing or empty/)
       end
     end
   end

--- a/spec/lib/program_importer_spec.rb
+++ b/spec/lib/program_importer_spec.rb
@@ -126,12 +126,12 @@ describe ProgramImporter do
     end
   end
 
-  describe '.import_file' do
+  describe '.check_and_import_file' do
     context 'with valid data' do
       it 'creates a program' do
         expect do
           path = Rails.root.join('spec/support/fixtures/valid_program.csv')
-          ProgramImporter.import_file(path)
+          ProgramImporter.check_and_import_file(path)
         end.to change(Program, :count)
       end
     end
@@ -140,8 +140,26 @@ describe ProgramImporter do
       it 'does not create a program' do
         expect do
           path = Rails.root.join('spec/support/fixtures/invalid_program.csv')
-          ProgramImporter.import_file(path)
+          ProgramImporter.check_and_import_file(path)
         end.not_to change(Program, :count)
+      end
+    end
+
+    context 'when file is missing but not required' do
+      it 'does not raise an error' do
+        expect do
+          path = Rails.root.join('spec/support/data/programs.csv')
+          ProgramImporter.check_and_import_file(path)
+        end.not_to raise_error
+      end
+    end
+
+    context 'when file is empty but not required' do
+      it 'does not raise an error' do
+        expect do
+          path = Rails.root.join('spec/support/fixtures/programs.csv')
+          ProgramImporter.check_and_import_file(path)
+        end.not_to raise_error
       end
     end
   end

--- a/spec/lib/regular_schedule_importer_spec.rb
+++ b/spec/lib/regular_schedule_importer_spec.rb
@@ -146,12 +146,12 @@ describe RegularScheduleImporter do
     end
   end
 
-  describe '.import_file' do
+  describe '.check_and_import_file' do
     context 'with valid data' do
       it 'creates a regular_schedule' do
         expect do
           path = Rails.root.join('spec/support/fixtures/valid_location_regular_schedule.csv')
-          RegularScheduleImporter.import_file(path)
+          RegularScheduleImporter.check_and_import_file(path)
         end.to change(RegularSchedule, :count)
       end
     end
@@ -160,8 +160,26 @@ describe RegularScheduleImporter do
       it 'does not create a regular_schedule' do
         expect do
           path = Rails.root.join('spec/support/fixtures/invalid_regular_schedule.csv')
-          RegularScheduleImporter.import_file(path)
+          RegularScheduleImporter.check_and_import_file(path)
         end.not_to change(RegularSchedule, :count)
+      end
+    end
+
+    context 'when file is missing but required' do
+      it 'raises an error' do
+        expect do
+          path = Rails.root.join('spec/support/data/regular_schedules.csv')
+          RegularScheduleImporter.check_and_import_file(path)
+        end.to raise_error(/missing or empty/)
+      end
+    end
+
+    context 'when file is empty and required' do
+      it 'raises an error' do
+        expect do
+          path = Rails.root.join('spec/support/fixtures/regular_schedules.csv')
+          RegularScheduleImporter.check_and_import_file(path)
+        end.to raise_error(/missing or empty/)
       end
     end
   end

--- a/spec/lib/service_importer_spec.rb
+++ b/spec/lib/service_importer_spec.rb
@@ -154,12 +154,12 @@ describe ServiceImporter do
     end
   end
 
-  describe '.import_file' do
+  describe '.check_and_import_file' do
     context 'with valid data' do
       it 'creates a service' do
         expect do
           path = Rails.root.join('spec/support/fixtures/valid_service.csv')
-          ServiceImporter.import_file(path)
+          ServiceImporter.check_and_import_file(path)
         end.to change(Service, :count)
       end
     end
@@ -168,8 +168,26 @@ describe ServiceImporter do
       it 'does not create a service' do
         expect do
           path = Rails.root.join('spec/support/fixtures/invalid_service.csv')
-          ServiceImporter.import_file(path)
+          ServiceImporter.check_and_import_file(path)
         end.not_to change(Service, :count)
+      end
+    end
+
+    context 'when file is missing but required' do
+      it 'raises an error' do
+        expect do
+          path = Rails.root.join('spec/support/data/services.csv')
+          ServiceImporter.check_and_import_file(path)
+        end.to raise_error(/missing or empty/)
+      end
+    end
+
+    context 'when file is empty and required' do
+      it 'raises an error' do
+        expect do
+          path = Rails.root.join('spec/support/fixtures/services.csv')
+          ServiceImporter.check_and_import_file(path)
+        end.to raise_error(/missing or empty/)
       end
     end
   end

--- a/spec/support/fixtures/addresses.csv
+++ b/spec/support/fixtures/addresses.csv
@@ -1,0 +1,1 @@
+id,location_id,street_1,street_2,city,state,postal_code,country_code

--- a/spec/support/fixtures/contacts.csv
+++ b/spec/support/fixtures/contacts.csv
@@ -1,0 +1,1 @@
+id,location_id,organization_id,service_id,title,email,department

--- a/spec/support/fixtures/holiday_schedules.csv
+++ b/spec/support/fixtures/holiday_schedules.csv
@@ -1,0 +1,1 @@
+id,location_id,service_id,start_date,end_date,closed,opens_at,closes_at

--- a/spec/support/fixtures/locations.csv
+++ b/spec/support/fixtures/locations.csv
@@ -1,0 +1,1 @@
+id,organization_id,accessibility,admin_emails,alternate_name,description,email,languages,latitude,longitude,name,transportation,virtual,website

--- a/spec/support/fixtures/mail_addresses.csv
+++ b/spec/support/fixtures/mail_addresses.csv
@@ -1,0 +1,1 @@
+id,location_id,attention,street_1,street_2,city,state,postal_code,country_code

--- a/spec/support/fixtures/organizations.csv
+++ b/spec/support/fixtures/organizations.csv
@@ -1,0 +1,1 @@
+id,accreditations,alternate_name,date_incorporated,description,email,funding_sources,legal_status,licenses,name,tax_id,tax_status,website

--- a/spec/support/fixtures/phones.csv
+++ b/spec/support/fixtures/phones.csv
@@ -1,0 +1,1 @@
+id,contact_id,location_id,organization_id,service_id,number,extension,department,number_type,vanity_number,country_prefix

--- a/spec/support/fixtures/programs.csv
+++ b/spec/support/fixtures/programs.csv
@@ -1,0 +1,1 @@
+id,organization_id,name,alternate_name

--- a/spec/support/fixtures/regular_schedules.csv
+++ b/spec/support/fixtures/regular_schedules.csv
@@ -1,0 +1,1 @@
+id,location_id,service_id,weekday,opens_at,closes_at

--- a/spec/support/fixtures/services.csv
+++ b/spec/support/fixtures/services.csv
@@ -1,0 +1,1 @@
+id,location_id,program_id,accepted_payments,alternate_name,description,eligibility,email,fees,funding_sources,how_to_apply,keywords,languages,name,required_documents,service_areas,status,wait_time,website


### PR DESCRIPTION
If a CSV file that is not required is either missing or present but
empty, the import script will skip it and won’t raise an error.

If a required file is missing or empty, then the rake task will be
aborted and an error message will appear explaining that the file is
missing or empty.

Closes #284.
