### PR TITLE
Add .gitattributes to enforce LF line endings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text eol=lf
+*.csv  eol=crlf
+*.dump binary
+*.png  binary
+*.jpg  binary
+*.gif  binary


### PR DESCRIPTION
This should allow Windows users to run the app in a virtual machine.
See this GitHub article for more details:
https://help.github.com/articles/dealing-with-line-endings/#per-repository-settings

Closes #278.
