### PR TITLE
Prevent discovery of existing email addresses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,4 +87,5 @@ group :development do
   gem 'spring'
   gem 'spring-commands-rspec'
   gem 'spring-watcher-listen'
+  gem 'letter_opener'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     ancestry (2.1.0)
       activerecord (>= 3.0.0)
     arel (6.0.0)
@@ -145,6 +146,10 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.9.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.3.0)
+      launchy (~> 2.2)
     listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -343,6 +348,7 @@ DEPENDENCIES
   jquery-rails (~> 4.0)
   kaminari
   kgio
+  letter_opener
   memcachier
   pg
   pg_search

--- a/app/controllers/admin/registrations_controller.rb
+++ b/app/controllers/admin/registrations_controller.rb
@@ -2,6 +2,8 @@ class Admin
   class RegistrationsController < Devise::RegistrationsController
     before_action :configure_permitted_parameters
 
+    include PrivateRegistration
+
     protected
 
     def configure_permitted_parameters

--- a/app/controllers/concerns/private_registration.rb
+++ b/app/controllers/concerns/private_registration.rb
@@ -1,0 +1,56 @@
+module PrivateRegistration
+  def create
+    build_resource(sign_up_params)
+
+    if resource.save
+      process_successful_registration
+    elsif resource_valid_except_for_duplicate_email?
+      process_private_registration
+    else
+      resource.errors[:email].delete_if { |e| e == 'has already been taken' }
+      process_unsuccessful_registration
+    end
+  end
+
+  private
+
+  def resource_valid_except_for_duplicate_email?
+    resource_class.find_by_email(resource.email).present? &&
+      only_email_error_is_duplicate?
+  end
+
+  def only_email_error_is_duplicate?
+    resource.errors.keys == [:email] &&
+      resource.errors[:email].uniq == ['has already been taken']
+  end
+
+  def process_private_registration
+    AdminMailer.existing_email_signup(resource).deliver_now
+    if is_flashing_format?
+      set_flash_message :notice, :signed_up_but_unconfirmed, email: resource.email
+    end
+    redirect_to path_for(resource)
+  end
+
+  def path_for(resource)
+    return new_admin_session_path if resource.is_a?(Admin)
+    return new_user_session_path if resource.is_a?(User)
+  end
+
+  def process_successful_registration
+    if is_flashing_format?
+      set_flash_message :notice, :"signed_up_but_#{resource.inactive_message}"
+    end
+    expire_data_after_sign_in!
+    respond_with resource, location: after_inactive_sign_up_path_for(resource)
+  end
+
+  def process_unsuccessful_registration
+    clean_up_passwords resource
+    @validatable = devise_mapping.validatable?
+    if @validatable
+      @minimum_password_length = resource_class.password_length.min
+    end
+    respond_with resource
+  end
+end

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -2,6 +2,8 @@ class User
   class RegistrationsController < Devise::RegistrationsController
     before_action :configure_permitted_parameters
 
+    include PrivateRegistration
+
     protected
 
     def configure_permitted_parameters

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,0 +1,31 @@
+class AdminMailer < ActionMailer::Base
+  default from: SETTINGS[:confirmation_email]
+
+  def existing_email_signup(resource)
+    @portal = portal_for(resource)
+    @sign_in_url = sign_in_url_for(resource)
+    @sign_up_url = sign_up_url_for(resource)
+    @password_url = password_url_for(resource)
+    mail(to: resource.email, subject: "Request to sign up on #{@portal}")
+  end
+
+  def portal_for(resource)
+    return t('titles.admin', brand: t('titles.brand')) if resource.is_a?(Admin)
+    return t('titles.developer', brand: t('titles.brand')) if resource.is_a?(User)
+  end
+
+  def sign_in_url_for(resource)
+    return new_admin_session_url(subdomain: ENV['ADMIN_SUBDOMAIN']) if resource.is_a?(Admin)
+    return new_user_session_url(subdomain: ENV['DEV_SUBDOMAIN']) if resource.is_a?(User)
+  end
+
+  def sign_up_url_for(resource)
+    return new_admin_registration_url(subdomain: ENV['ADMIN_SUBDOMAIN']) if resource.is_a?(Admin)
+    return new_user_registration_url(subdomain: ENV['DEV_SUBDOMAIN']) if resource.is_a?(User)
+  end
+
+  def password_url_for(resource)
+    return new_admin_password_url(subdomain: ENV['ADMIN_SUBDOMAIN']) if resource.is_a?(Admin)
+    return new_user_password_url(subdomain: ENV['DEV_SUBDOMAIN']) if resource.is_a?(User)
+  end
+end

--- a/app/views/admin_mailer/existing_email_signup.html.haml
+++ b/app/views/admin_mailer/existing_email_signup.html.haml
@@ -1,0 +1,9 @@
+%p A request was made to use this email address to sign up for an account on #{@portal}. This email address is already in use. If you requested this change, please use the following link to sign in to #{@portal}:
+
+%p= link_to @sign_in_url, @sign_in_url, target: '_blank'
+
+%p If you would like to create a new account on #{@portal}, please #{link_to 'sign up', @sign_up_url, target: '_blank'} with a different email address.
+
+%p If you cannot remember your password, please follow the instructions for #{link_to 'resetting your password', @password_url, target: '_blank'}.
+
+%p If you did not request a new account, please ignore this email.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,6 +27,7 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = { host: 'lvh.me:8080' }
+  config.action_mailer.delivery_method = :letter_opener
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -67,7 +67,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # :http_auth and :token_auth by adding those symbols to the array below.

--- a/spec/features/admin/sign_up_spec.rb
+++ b/spec/features/admin/sign_up_spec.rb
@@ -45,4 +45,97 @@ feature 'Signing up for a new admin account' do
     sign_up_admin('Moncef', 'moncef@foo.com', 'ohanatest', 'ohana')
     expect(page).to have_content "Password confirmation doesn't match Password"
   end
+
+  context 'when signing up with existing email', email: true do
+    before(:each) do
+      sign_up_admin('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+      sign_up_admin('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+    end
+
+    def portal_name
+      I18n.t('titles.admin', brand: I18n.t('titles.brand'))
+    end
+
+    it 'does not reveal that the email has already been taken' do
+      expect(page).not_to have_content 'Email has already been taken'
+    end
+
+    it 'redirects back to admin portal sign in page' do
+      expect(current_path).to eq new_admin_session_path
+    end
+
+    it 'sends an email to the user informing them of sign up' do
+      expect(last_email.body).to include 'email address is already in use'
+    end
+
+    it 'mentions the admin portal' do
+      expect(last_email.body).to include portal_name
+    end
+
+    it 'links to the admin sign in page' do
+      expect(last_email.body).to have_link new_admin_session_path
+    end
+
+    it 'links to the admin sign up page' do
+      expect(last_email.body).
+        to have_link 'sign up', href: 'http://example.com/admin/sign_up'
+    end
+
+    it 'links to the admin reset password page' do
+      expect(last_email.body).
+        to have_link 'resetting your password', href: 'http://example.com/admin/password/new'
+    end
+
+    it 'mentions the admin portal in the email subject' do
+      expect(last_email.subject).to eq "Request to sign up on #{portal_name}"
+    end
+  end
+
+  describe 'duplicate email along with other validation errors' do
+    shared_examples 'does not reveal existing email' do
+      it 'does not display duplicate email error' do
+        expect(page).not_to have_content 'Email has already been taken'
+      end
+
+      it 'does not send an email', email: true do
+        expect(ActionMailer::Base.deliveries.size).to eq 1
+      end
+    end
+
+    context 'when duplicate email and name is missing during sign up' do
+      before(:each) do
+        sign_up_admin('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+        sign_up_admin('', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+      end
+
+      it_behaves_like 'does not reveal existing email'
+    end
+
+    context 'when duplicate email and password is missing during sign up' do
+      before(:each) do
+        sign_up_admin('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+        sign_up_admin('', 'moncef@foo.com', '', 'ohanatest')
+      end
+
+      it_behaves_like 'does not reveal existing email'
+    end
+
+    context 'when duplicate email and password_confirmation invalid during sign up' do
+      before(:each) do
+        sign_up_admin('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+        sign_up_admin('Moncef', 'moncef@foo.com', 'ohanatest', '')
+      end
+
+      it_behaves_like 'does not reveal existing email'
+    end
+
+    context 'when duplicate email and password is too short during sign up' do
+      before(:each) do
+        sign_up_admin('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+        sign_up_admin('Moncef', 'moncef@foo.com', 'foo', 'foo')
+      end
+
+      it_behaves_like 'does not reveal existing email'
+    end
+  end
 end

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -32,11 +32,109 @@ feature 'Signing up' do
     expect(page).to have_content "Password confirmation doesn't match Password"
   end
 
+  scenario 'when password is too short' do
+    sign_up('Moncef', 'moncef@foo.com', 'foo', 'foo')
+    expect(page).to have_content 'Password is too short'
+  end
+
   scenario 'with custom mailer' do
     reset_email
     sign_up('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
     expect(first_email.body).to include('developer')
     expect(first_email.body).to include('documentation')
     expect(first_email.body).to include('http://codeforamerica.github.io/ohana-api-docs/')
+  end
+
+  context 'when signing up with existing email', email: true do
+    before(:each) do
+      sign_up('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+      sign_up('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+    end
+
+    def portal_name
+      I18n.t('titles.developer', brand: I18n.t('titles.brand'))
+    end
+
+    it 'does not reveal that the email has already been taken' do
+      expect(page).not_to have_content 'Email has already been taken'
+    end
+
+    it 'redirects back to developer portal sign in page' do
+      expect(current_path).to eq new_user_session_path
+    end
+
+    it 'sends an email to the user informing them of sign up' do
+      expect(last_email.body).to include 'email address is already in use'
+    end
+
+    it 'mentions the developer portal' do
+      expect(last_email.body).to include portal_name
+    end
+
+    it 'links to the developer sign in page' do
+      expect(last_email.body).to have_link new_user_session_path
+    end
+
+    it 'links to the developer sign up page' do
+      expect(last_email.body).
+        to have_link 'sign up', href: 'http://example.com/users/sign_up'
+    end
+
+    it 'links to the developer reset password page' do
+      expect(last_email.body).
+        to have_link 'resetting your password', href: 'http://example.com/users/password/new'
+    end
+
+    it 'mentions the developer portal in the email subject' do
+      expect(last_email.subject).to eq "Request to sign up on #{portal_name}"
+    end
+  end
+
+  describe 'duplicate email along with other validation errors' do
+    shared_examples 'does not reveal existing email' do
+      it 'does not display duplicate email error' do
+        expect(page).not_to have_content 'Email has already been taken'
+      end
+
+      it 'does not send an email', email: true do
+        expect(ActionMailer::Base.deliveries.size).to eq 1
+      end
+    end
+
+    context 'when duplicate email and name is missing during sign up' do
+      before(:each) do
+        sign_up('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+        sign_up('', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+      end
+
+      it_behaves_like 'does not reveal existing email'
+    end
+
+    context 'when duplicate email and password is missing during sign up' do
+      before(:each) do
+        sign_up('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+        sign_up('', 'moncef@foo.com', '', 'ohanatest')
+      end
+
+      it_behaves_like 'does not reveal existing email'
+    end
+
+    context 'when duplicate email and password_confirmation invalid during sign up' do
+      before(:each) do
+        sign_up('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+        sign_up('Moncef', 'moncef@foo.com', 'ohanatest', '')
+      end
+
+      it_behaves_like 'does not reveal existing email'
+    end
+
+    context 'when duplicate email and password is too short during sign up' do
+      before(:each) do
+        sign_up('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
+        sign_up('Moncef', 'moncef@foo.com', 'foo', 'foo')
+      end
+
+      it_behaves_like 'does not reveal existing email'
+    end
   end
 end

--- a/spec/support/mailer_macros.rb
+++ b/spec/support/mailer_macros.rb
@@ -1,6 +1,16 @@
+RSpec.configure do |config|
+  config.before(:each, email: true) do
+    ActionMailer::Base.deliveries = []
+  end
+end
+
 module MailerMacros
   def first_email
     ActionMailer::Base.deliveries.first
+  end
+
+  def last_email
+    ActionMailer::Base.deliveries.last
   end
 
   def reset_email


### PR DESCRIPTION
Devise allows user enumeration by default, but they provide a `paranoid` setting to prevent enumeration when resetting a password or resending confirmation instructions. This PR turns the `paranoid` setting on.

In addition, this PR also makes sure that enumeration is not possible during sign up. Devise does not provide a way to prevent user enumeration for the `registerable` module, so I wrote my own by overriding the `create` method in the Devise registrations controller.

So now, when you try to sign up with an existing email address, instead of getting an error message that says the email has already been taken, you get the same success notice as you would during a regular successful sign up, and an email is sent to the user letting them know that a request was made to sign up with their email address, and provides the user with helpful links and text depending on whether or not they initiated that request.