### PR TITLE
Only validate state_province length for US and CA

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -11,7 +11,9 @@ class Address < ActiveRecord::Base
             :country,
             presence: { message: I18n.t('errors.messages.blank_for_address') }
 
-  validates :state_province, length: { maximum: 2, minimum: 2 }
+  validates :state_province,
+            presence: { message: I18n.t('errors.messages.blank_for_address') },
+            state_province: true
 
   validates :country, length: { maximum: 2, minimum: 2 }
 

--- a/app/models/mail_address.rb
+++ b/app/models/mail_address.rb
@@ -12,7 +12,9 @@ class MailAddress < ActiveRecord::Base
             :location,
             presence: { message: I18n.t('errors.messages.blank_for_mail_address') }
 
-  validates :state_province, length: { maximum: 2, minimum: 2 }
+  validates :state_province,
+            presence: { message: I18n.t('errors.messages.blank_for_address') },
+            state_province: true
 
   validates :country, length: { maximum: 2, minimum: 2 }
 

--- a/app/validators/state_province_validator.rb
+++ b/app/validators/state_province_validator.rb
@@ -1,0 +1,13 @@
+class StateProvinceValidator < ActiveModel::EachValidator
+  COUNTRIES_NEEDING_VALIDATION = %w(US CA).freeze
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+    return unless COUNTRIES_NEEDING_VALIDATION.include?(record.country)
+    default_message = I18n.t('errors.messages.invalid_state_province')
+
+    unless value.size == 2
+      record.errors[attribute] << (options[:message] || default_message)
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,13 +71,12 @@ en:
       invalid_fax: 'is not a valid US fax number'
       invalid_phone: 'is not a valid US phone or fax number'
       invalid_service_area: 'is not a valid service area'
-      invalid_state_province: 'Please enter a valid 2-letter state abbreviation'
+      invalid_state_province: 'Please enter a valid 2-letter state or province abbreviation'
       invalid_url: 'is not a valid URL'
       invalid_weekday: 'is not a valid weekday'
       invalid_zip: 'is not a valid ZIP code'
       no_address: "Unless it's virtual, a location must have an address."
       not_an_array: 'is not an Array.'
-
 
   titles:
     brand: "Ohana API"

--- a/spec/features/admin/locations/update_address_spec.rb
+++ b/spec/features/admin/locations/update_address_spec.rb
@@ -76,7 +76,7 @@ feature "Updating a location's address with invalid values" do
     update_street_address(address_1: '123', city: 'Par', state_province: 'V',
                           postal_code: '12345', country: 'US')
     click_button 'Save changes'
-    expect(page).to have_content 'too short'
+    expect(page).to have_content t('errors.messages.invalid_state_province')
   end
 
   scenario 'with an invalid zip' do

--- a/spec/features/admin/locations/update_mail_address_spec.rb
+++ b/spec/features/admin/locations/update_mail_address_spec.rb
@@ -94,7 +94,7 @@ feature 'Updating mailing address with invalid values' do
     update_mailing_address(address_1: '123', city: 'Par', state_province: 'V',
                            postal_code: '12345', country: 'US')
     click_button 'Save changes'
-    expect(page).to have_content 'too short'
+    expect(page).to have_content t('errors.messages.invalid_state_province')
   end
 
   scenario 'with an invalid zip' do

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -21,14 +21,6 @@ describe Address do
   it { is_expected.to validate_presence_of(:country).with_message("can't be blank for Address") }
 
   it do
-    is_expected.to validate_length_of(:state_province).
-      is_at_least(2).
-      is_at_most(2).
-      with_short_message('is too short (minimum is 2 characters)').
-      with_long_message('is too long (maximum is 2 characters)')
-  end
-
-  it do
     is_expected.to validate_length_of(:country).
       is_at_least(2).
       is_at_most(2).
@@ -67,6 +59,47 @@ describe Address do
     it 'calls reset_location_coordinates after destroy' do
       expect(@loc.address).to receive(:reset_location_coordinates)
       @loc.address.destroy
+    end
+  end
+
+  describe 'state_province validations' do
+    context 'when country is US' do
+      it 'validates length is 2 characters' do
+        address = build(:address, country: 'US', state_province: 'California')
+        address.save
+
+        expect(address.errors[:state_province].first).
+          to eq t('errors.messages.invalid_state_province')
+      end
+    end
+
+    context 'when country is CA' do
+      it 'validates length is 2 characters' do
+        address = build(:address, country: 'CA', state_province: 'Ontario')
+        address.save
+
+        expect(address.errors[:state_province].first).
+          to eq t('errors.messages.invalid_state_province')
+      end
+    end
+
+    context 'when country is not CA or US' do
+      it 'does not validate length' do
+        address = build(:address, country: 'UK', state_province: 'Kent')
+        address.save
+
+        expect(address.errors[:state_province]).to be_empty
+      end
+    end
+
+    context 'when country is not CA or US' do
+      it 'validates presence' do
+        address = build(:address, country: 'UK', state_province: '')
+        address.save
+
+        expect(address.errors[:state_province].first).
+          to eq t('errors.messages.blank_for_address')
+      end
     end
   end
 end

--- a/spec/models/mail_address_spec.rb
+++ b/spec/models/mail_address_spec.rb
@@ -22,14 +22,6 @@ describe MailAddress do
   it { is_expected.to validate_presence_of(:country).with_message("can't be blank for Mail Address") }
 
   it do
-    is_expected.to validate_length_of(:state_province).
-      is_at_least(2).
-      is_at_most(2).
-      with_short_message('is too short (minimum is 2 characters)').
-      with_long_message('is too long (maximum is 2 characters)')
-  end
-
-  it do
     is_expected.to validate_length_of(:country).
       is_at_least(2).
       is_at_most(2).
@@ -61,6 +53,47 @@ describe MailAddress do
       expect(address.state_province).to eq('CA')
       expect(address.postal_code).to eq('94020')
       expect(address.country).to eq('US')
+    end
+  end
+
+  describe 'state_province validations' do
+    context 'when country is US' do
+      it 'validates length is 2 characters' do
+        mail_address = build(:mail_address, country: 'US', state_province: 'California')
+        mail_address.save
+
+        expect(mail_address.errors[:state_province].first).
+          to eq t('errors.messages.invalid_state_province')
+      end
+    end
+
+    context 'when country is CA' do
+      it 'validates length is 2 characters' do
+        mail_address = build(:mail_address, country: 'CA', state_province: 'Ontario')
+        mail_address.save
+
+        expect(mail_address.errors[:state_province].first).
+          to eq t('errors.messages.invalid_state_province')
+      end
+    end
+
+    context 'when country is not CA or US' do
+      it 'does not validate length' do
+        mail_address = build(:mail_address, country: 'UK', state_province: 'Kent')
+        mail_address.save
+
+        expect(mail_address.errors[:state_province]).to be_empty
+      end
+    end
+
+    context 'when country is not CA or US' do
+      it 'validates presence' do
+        mail_address = build(:mail_address, country: 'UK', state_province: '')
+        mail_address.save
+
+        expect(mail_address.errors[:state_province].first).
+          to eq t('errors.messages.blank_for_mail_address')
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,7 @@ RSpec.configure do |config|
   config.include Requests::RequestHelpers, type: :request
   config.include DefaultHeaders, type: :request
   config.include MailerMacros
+  config.include AbstractController::Translation
 
   # rspec-rails 3+ will no longer automatically infer an example group's spec
   # type from the file location. You can explicitly opt-in to this feature by


### PR DESCRIPTION
From my initial research, it looks like only the US and Canada use 2-letter abbreviations for states/provinces. If we come across any other ones, we can add them then.