### PR TITLE
Display Ohana API version for super admins.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def version
+    @version ||= File.read('VERSION')
+  end
 end

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -32,4 +32,5 @@
     %p= link_to 'Download all regular schedules as CSV', admin_csv_regular_schedules_path, class: 'btn btn-primary'
     %p= link_to 'Download all services as CSV', admin_csv_services_path, class: 'btn btn-primary'
 
-
+    %hr
+    Ohana API #{link_to "v#{version}", 'https://github.com/codeforamerica/ohana-api/blob/master/CHANGELOG.md'}

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -221,4 +221,29 @@ feature 'Admin Home page' do
         to have_link('Download all services as CSV', admin_csv_services_path)
     end
   end
+
+  describe 'Ohana API version' do
+    before do
+      allow(File).to receive(:read).with('VERSION').and_return('1.0.0')
+    end
+    let(:prefix) { 'https://github.com/codeforamerica/ohana-api/blob/master/' }
+
+    context 'super admin' do
+      it 'displays Ohana API version number' do
+        login_super_admin
+        visit '/admin'
+
+        expect(page).to have_link 'v1.0.0', href: "#{prefix}CHANGELOG.md"
+      end
+    end
+
+    context 'regular admin' do
+      it 'does not display Ohana API version number' do
+        login_admin
+        visit '/admin'
+
+        expect(page).to_not have_link 'v1.0.0', href: "#{prefix}CHANGELOG.md"
+      end
+    end
+  end
 end


### PR DESCRIPTION
The version number is based on the VERSION file from the codeforamerica/ohana-api repo. Because deployments can manage and customize their instances of Ohana API however they choose, the version number does not necessarily mean that a particular deployment is exactly in sync with the upstream repo. It should be used as a general indicator of when an update was last peformed.

The version number appears in the footer of the admin home page, and only for super admins. It also links to the ohana-api repo's Changelog to make it easy to see what has changed since a particular version.

Closes #294.