### PR TITLE
Make meta description more generic for different Ohana deployments

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,7 +3,7 @@
   %head
     %meta{ content: 'width=device-width, initial-scale=1.0', name: 'viewport' }
       %title= content_for?(:title) ? yield(:title) : t('titles.brand')
-      %meta{ content: content_for?(:description) ? yield(:description) : "An open-source API of human services, farmers markets, parks, libraries, museums, and other organizations in #{t('admin.api_location')}", name: 'description' }
+      %meta{ content: content_for?(:description) ? yield(:description) : "An open-source API of human services and other organizations in #{t('admin.api_location')}", name: 'description' }
         = stylesheet_link_tag 'application', media: 'all'
         = csrf_meta_tags
         = yield(:head)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,7 +2,7 @@
 %html
   %head
     %meta{ content: 'width=device-width, initial-scale=1.0', name: 'viewport' }
-      %title= content_for?(:title) ? yield(:title) : 'Ohana API'
+      %title= content_for?(:title) ? yield(:title) : t('titles.brand')
       %meta{ content: content_for?(:description) ? yield(:description) : "An open-source API of human services, farmers markets, parks, libraries, museums, and other organizations in #{t('admin.api_location')}", name: 'description' }
         = stylesheet_link_tag 'application', media: 'all'
         = csrf_meta_tags

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,7 +3,7 @@
   %head
     %meta{ content: 'width=device-width, initial-scale=1.0', name: 'viewport' }
       %title= content_for?(:title) ? yield(:title) : 'Ohana API'
-      %meta{ content: content_for?(:description) ? yield(:description) : 'An open-source API of human services, farmers markets, parks, libraries, museums, and other organizations in San Mateo County', name: 'description' }
+      %meta{ content: content_for?(:description) ? yield(:description) : "An open-source API of human services, farmers markets, parks, libraries, museums, and other organizations in #{t('admin.api_location')}", name: 'description' }
         = stylesheet_link_tag 'application', media: 'all'
         = csrf_meta_tags
         = yield(:head)


### PR DESCRIPTION
This PR removes a hard-coded "San Mateo County" from the default `<meta name="description">`, replacing it with the appropriate `admin.api_location` from the locale files.