### PR TITLE
Improve import script error handling.

### DIFF
--- a/lib/category_importer.rb
+++ b/lib/category_importer.rb
@@ -1,18 +1,14 @@
 class CategoryImporter < EntityImporter
   def valid?
-    @valid ||= valid_headers? && categories.all?(&:valid?)
+    @valid ||= categories.all?(&:valid?)
   end
 
   def errors
-    header_errors + ImporterErrors.messages_for(categories)
+    ImporterErrors.messages_for(categories)
   end
 
   def import
     categories.each(&:save!) if valid?
-  end
-
-  def required_headers
-    %w(taxonomy_id name parent_id parent_name).map(&:to_sym)
   end
 
   protected
@@ -21,5 +17,9 @@ class CategoryImporter < EntityImporter
     @categories ||= csv_entries.map(&:to_hash).map do |p|
       CategoryPresenter.new(p).to_category
     end
+  end
+
+  def self.required_headers
+    %w(taxonomy_id name parent_id parent_name)
   end
 end

--- a/lib/contact_importer.rb
+++ b/lib/contact_importer.rb
@@ -1,19 +1,14 @@
 class ContactImporter < EntityImporter
   def valid?
-    @valid ||= valid_headers? && contacts.all?(&:valid?)
+    @valid ||= contacts.all?(&:valid?)
   end
 
   def errors
-    header_errors + ImporterErrors.messages_for(contacts)
+    ImporterErrors.messages_for(contacts)
   end
 
   def import
     contacts.each(&:save!) if valid?
-  end
-
-  def required_headers
-    %w(id location_id organization_id service_id department email name
-       title).map(&:to_sym)
   end
 
   protected
@@ -22,5 +17,10 @@ class ContactImporter < EntityImporter
     @contacts ||= csv_entries.map(&:to_hash).map do |p|
       ContactPresenter.new(p).to_contact
     end
+  end
+
+  def self.required_headers
+    %w(id location_id organization_id service_id department email name
+       title)
   end
 end

--- a/lib/entity_importer.rb
+++ b/lib/entity_importer.rb
@@ -7,13 +7,9 @@ EntityImporter = Struct.new(:content) do
   end
 
   def self.check_and_import_file(path)
-    file = FileChecker.new(path)
+    FileChecker.new(path, required_headers).validate
 
-    return process_import(path) if file.available? && file.entries?
-
-    if file.required_but_missing? || file.required_but_empty?
-      fail "#{file.filename} is required but is missing or empty"
-    end
+    process_import(path)
   end
 
   def self.process_import(path)
@@ -21,28 +17,9 @@ EntityImporter = Struct.new(:content) do
     importer.errors.each { |e| Kernel.puts(e) } unless importer.valid?
   end
 
-  def valid_headers?
-    missing_headers.empty?
-  end
-
   protected
-
-  def header_errors
-    missing_headers.map { |header| "#{header} column is missing" }
-  end
-
-  def missing_headers
-    required_headers - headers
-  end
 
   def csv_entries
     @csv_entries ||= CSV.new(content, headers: true, header_converters: :symbol).entries
-  end
-
-  def headers
-    @headers ||= csv_entries.first.headers
-  end
-
-  def required_headers
   end
 end

--- a/lib/holiday_schedule_importer.rb
+++ b/lib/holiday_schedule_importer.rb
@@ -1,19 +1,14 @@
 class HolidayScheduleImporter < EntityImporter
   def valid?
-    @valid ||= valid_headers? && holiday_schedules.all?(&:valid?)
+    @valid ||= holiday_schedules.all?(&:valid?)
   end
 
   def errors
-    header_errors + ImporterErrors.messages_for(holiday_schedules)
+    ImporterErrors.messages_for(holiday_schedules)
   end
 
   def import
     holiday_schedules.each(&:save!) if valid?
-  end
-
-  def required_headers
-    %w(id location_id service_id closed start_date end_date opens_at
-       closes_at).map(&:to_sym)
   end
 
   protected
@@ -22,5 +17,10 @@ class HolidayScheduleImporter < EntityImporter
     @holiday_schedules ||= csv_entries.map(&:to_hash).map do |p|
       HolidaySchedulePresenter.new(p).to_holiday_schedule
     end
+  end
+
+  def self.required_headers
+    %w(id location_id service_id closed start_date end_date opens_at
+       closes_at)
   end
 end

--- a/lib/mail_address_importer.rb
+++ b/lib/mail_address_importer.rb
@@ -1,19 +1,14 @@
 class MailAddressImporter < EntityImporter
   def valid?
-    @valid ||= valid_headers? && mail_addresses.all?(&:valid?)
+    @valid ||= mail_addresses.all?(&:valid?)
   end
 
   def errors
-    header_errors + ImporterErrors.messages_for(mail_addresses)
+    ImporterErrors.messages_for(mail_addresses)
   end
 
   def import
     mail_addresses.each(&:save!) if valid?
-  end
-
-  def required_headers
-    %w(id location_id attention address_1 address_2 city state_province postal_code
-       country).map(&:to_sym)
   end
 
   protected
@@ -22,5 +17,10 @@ class MailAddressImporter < EntityImporter
     @mail_addresses ||= csv_entries.map(&:to_hash).map do |p|
       MailAddressPresenter.new(p).to_mail_address
     end
+  end
+
+  def self.required_headers
+    %w(id location_id attention address_1 address_2 city state_province postal_code
+       country)
   end
 end

--- a/lib/organization_importer.rb
+++ b/lib/organization_importer.rb
@@ -1,20 +1,14 @@
 class OrganizationImporter < EntityImporter
   def valid?
-    @valid ||= valid_headers? && organizations.all?(&:valid?)
+    @valid ||= organizations.all?(&:valid?)
   end
 
   def errors
-    header_errors + ImporterErrors.messages_for(organizations)
+    ImporterErrors.messages_for(organizations)
   end
 
   def import
     organizations.each(&:save!) if valid?
-  end
-
-  def required_headers
-    %w(id accreditations alternate_name date_incorporated
-       description email funding_sources legal_status
-       licenses name tax_id tax_status website).map(&:to_sym)
   end
 
   protected
@@ -23,5 +17,11 @@ class OrganizationImporter < EntityImporter
     csv_entries.map(&:to_hash).map do |p|
       OrganizationPresenter.new(p).to_org
     end
+  end
+
+  def self.required_headers
+    %w(id accreditations alternate_name date_incorporated
+       description email funding_sources legal_status
+       licenses name tax_id tax_status website)
   end
 end

--- a/lib/phone_importer.rb
+++ b/lib/phone_importer.rb
@@ -1,19 +1,14 @@
 class PhoneImporter < EntityImporter
   def valid?
-    @valid ||= valid_headers? && phones.all?(&:valid?)
+    @valid ||= phones.all?(&:valid?)
   end
 
   def errors
-    header_errors + ImporterErrors.messages_for(phones)
+    ImporterErrors.messages_for(phones)
   end
 
   def import
     phones.each(&:save!) if valid?
-  end
-
-  def required_headers
-    %w(id location_id organization_id service_id contact_id department
-       extension number number_type vanity_number country_prefix).map(&:to_sym)
   end
 
   protected
@@ -22,5 +17,10 @@ class PhoneImporter < EntityImporter
     @phones ||= csv_entries.map(&:to_hash).map do |p|
       PhonePresenter.new(p).to_phone
     end
+  end
+
+  def self.required_headers
+    %w(id location_id organization_id service_id contact_id department
+       extension number number_type vanity_number country_prefix)
   end
 end

--- a/lib/program_importer.rb
+++ b/lib/program_importer.rb
@@ -1,18 +1,14 @@
 class ProgramImporter < EntityImporter
   def valid?
-    @valid ||= valid_headers? && programs.all?(&:valid?)
+    @valid ||= programs.all?(&:valid?)
   end
 
   def errors
-    header_errors + ImporterErrors.messages_for(programs)
+    ImporterErrors.messages_for(programs)
   end
 
   def import
     programs.each(&:save!) if valid?
-  end
-
-  def required_headers
-    %w(id organization_id name alternate_name).map(&:to_sym)
   end
 
   protected
@@ -21,5 +17,9 @@ class ProgramImporter < EntityImporter
     @programs ||= csv_entries.map(&:to_hash).map do |p|
       ProgramPresenter.new(p).to_program
     end
+  end
+
+  def self.required_headers
+    %w(id organization_id name alternate_name)
   end
 end

--- a/lib/regular_schedule_importer.rb
+++ b/lib/regular_schedule_importer.rb
@@ -1,18 +1,14 @@
 class RegularScheduleImporter < EntityImporter
   def valid?
-    @valid ||= valid_headers? && regular_schedules.all?(&:valid?)
+    @valid ||= regular_schedules.all?(&:valid?)
   end
 
   def errors
-    header_errors + ImporterErrors.messages_for(regular_schedules)
+    ImporterErrors.messages_for(regular_schedules)
   end
 
   def import
     regular_schedules.each(&:save!) if valid?
-  end
-
-  def required_headers
-    %w(id location_id service_id weekday opens_at closes_at).map(&:to_sym)
   end
 
   protected
@@ -21,5 +17,9 @@ class RegularScheduleImporter < EntityImporter
     @regular_schedules ||= csv_entries.map(&:to_hash).map do |p|
       RegularSchedulePresenter.new(p).to_regular_schedule
     end
+  end
+
+  def self.required_headers
+    %w(id location_id service_id weekday opens_at closes_at)
   end
 end

--- a/lib/service_importer.rb
+++ b/lib/service_importer.rb
@@ -1,20 +1,14 @@
 class ServiceImporter < EntityImporter
   def valid?
-    @valid ||= valid_headers? && services.all?(&:valid?)
+    @valid ||= services.all?(&:valid?)
   end
 
   def errors
-    header_errors + ImporterErrors.messages_for(services)
+    ImporterErrors.messages_for(services)
   end
 
   def import
     services.each(&:save!) if valid?
-  end
-
-  def required_headers
-    %w(id location_id program_id accepted_payments alternate_name description
-       eligibility email fees funding_sources application_process languages name
-       required_documents service_areas status website wait_time).map(&:to_sym)
   end
 
   protected
@@ -23,5 +17,11 @@ class ServiceImporter < EntityImporter
     @services ||= csv_entries.map(&:to_hash).map do |p|
       ServicePresenter.new(p).to_service
     end
+  end
+
+  def self.required_headers
+    %w(id location_id program_id accepted_payments alternate_name description
+       eligibility email fees funding_sources application_process languages name
+       required_documents service_areas status website wait_time)
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -5,21 +5,21 @@ namespace :import do
 
   desc 'Imports organizations'
   task :organizations, [:path] => :environment do |_, args|
-    Kernel.puts('Importing your organizations...')
+    Kernel.puts('...Importing your organizations...')
     args.with_defaults(path: Rails.root.join('data/organizations.csv'))
     OrganizationImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports programs'
   task :programs, [:path] => :environment do |_, args|
-    Kernel.puts('Importing your programs...')
+    Kernel.puts('...Importing your programs...')
     args.with_defaults(path: Rails.root.join('data/programs.csv'))
     ProgramImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports locations'
   task :locations, [:path, :addresses_path] => :environment do |_, args|
-    Kernel.puts('Importing your locations and addresses...')
+    Kernel.puts('...Importing your locations and addresses...')
     args.with_defaults(
       path: Rails.root.join('data/locations.csv'),
       addresses_path: Rails.root.join('data/addresses.csv')
@@ -29,49 +29,49 @@ namespace :import do
 
   desc 'Imports taxonomy'
   task :taxonomy, [:path] => :environment do |_, args|
-    Kernel.puts('Importing your taxonomy...')
+    Kernel.puts('...Importing your taxonomy...')
     args.with_defaults(path: Rails.root.join('data/taxonomy.csv'))
     CategoryImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports services'
   task :services, [:path] => :environment do |_, args|
-    Kernel.puts('Importing your services...')
+    Kernel.puts('...Importing your services...')
     args.with_defaults(path: Rails.root.join('data/services.csv'))
     ServiceImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports mail addresses'
   task :mail_addresses, [:path] => :environment do |_, args|
-    Kernel.puts('Importing your mail addresses...')
+    Kernel.puts('...Importing your mail addresses...')
     args.with_defaults(path: Rails.root.join('data/mail_addresses.csv'))
     MailAddressImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports contacts'
   task :contacts, [:path] => :environment do |_, args|
-    Kernel.puts('Importing your contacts...')
+    Kernel.puts('...Importing your contacts...')
     args.with_defaults(path: Rails.root.join('data/contacts.csv'))
     ContactImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports phones'
   task :phones, [:path] => :environment do |_, args|
-    Kernel.puts('Importing your phones...')
+    Kernel.puts('...Importing your phones...')
     args.with_defaults(path: Rails.root.join('data/phones.csv'))
     PhoneImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports regular_schedules'
   task :regular_schedules, [:path] => :environment do |_, args|
-    Kernel.puts('Importing your regular_schedules...')
+    Kernel.puts('...Importing your regular_schedules...')
     args.with_defaults(path: Rails.root.join('data/regular_schedules.csv'))
     RegularScheduleImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports holiday_schedules'
   task :holiday_schedules, [:path] => :environment do |_, args|
-    Kernel.puts('Importing your holiday_schedules...')
+    Kernel.puts('...Importing your holiday_schedules...')
     args.with_defaults(path: Rails.root.join('data/holiday_schedules.csv'))
     HolidayScheduleImporter.check_and_import_file(args[:path])
   end

--- a/spec/lib/file_checker_spec.rb
+++ b/spec/lib/file_checker_spec.rb
@@ -1,0 +1,183 @@
+require 'rails_helper'
+
+describe FileChecker do
+  let(:required_and_full) { Rails.root.join('spec/support/fixtures/locations.csv') }
+  let(:required_but_empty) { Rails.root.join('spec/support/fixtures/services.csv') }
+  let(:required_but_missing) { Rails.root.join('spec/support/data/services.csv') }
+  let(:missing_not_required) { Rails.root.join('spec/support/fixtures/foo.csv') }
+  let(:empty_not_required) { Rails.root.join('spec/support/fixtures/taxonomy.csv') }
+  let(:full_not_required) { Rails.root.join('spec/support/fixtures/programs.csv') }
+  let(:invalid_headers) { Rails.root.join('spec/support/fixtures/invalid_program_headers.csv') }
+  let(:required_headers) { %w(id organization_id name alternate_name) }
+
+  subject(:checker) { FileChecker.new(path, required_headers) }
+
+  describe '#filename' do
+    let(:path) { required_and_full }
+
+    its(:filename) { is_expected.to eq 'locations.csv' }
+  end
+
+  describe '#missing?' do
+    context 'when the file exists' do
+      let(:path) { required_and_full }
+
+      it { is_expected.to_not be_missing }
+    end
+
+    context 'when the file does not exist' do
+      let(:path) { missing_not_required }
+
+      it { is_expected.to be_missing }
+    end
+  end
+
+  describe '#required_but_missing?' do
+    context 'when the file is required and present' do
+      let(:path) { required_and_full }
+
+      it { is_expected.to_not be_required_but_missing }
+    end
+
+    context 'when the file is required and missing' do
+      let(:path) { required_but_missing }
+
+      it { is_expected.to be_required_but_missing }
+    end
+
+    context 'when the file is missing but not required' do
+      let(:path) { missing_not_required }
+
+      it { is_expected.to_not be_required_but_missing }
+    end
+
+    context 'when the file is present but not required' do
+      let(:path) { empty_not_required }
+
+      it { is_expected.to_not be_required_but_missing }
+    end
+  end
+
+  describe '#required_but_empty?' do
+    context 'when the file is required and has content' do
+      let(:path) { required_and_full }
+
+      it { is_expected.to_not be_required_but_empty }
+    end
+
+    context 'when the file is required and empty' do
+      let(:path) { required_but_empty }
+
+      it { is_expected.to be_required_but_empty }
+    end
+
+    context 'when the file is not required but empty' do
+      let(:path) { empty_not_required }
+
+      it { is_expected.to_not be_required_but_empty }
+    end
+
+    context 'when the file is not required and has content' do
+      let(:path) { full_not_required }
+
+      it { is_expected.to_not be_required_but_empty }
+    end
+  end
+
+  describe '#missing_or_empty?' do
+    context 'when the file is required but missing' do
+      let(:path) { required_but_missing }
+
+      it { is_expected.to be_missing_or_empty }
+    end
+
+    context 'when the file is not required but missing' do
+      let(:path) { missing_not_required }
+
+      it { is_expected.to_not be_missing_or_empty }
+    end
+
+    context 'when the file is not required but empty' do
+      let(:path) { empty_not_required }
+
+      it { is_expected.to_not be_missing_or_empty }
+    end
+
+    context 'when the file is required but empty' do
+      let(:path) { required_but_empty }
+
+      it { is_expected.to be_missing_or_empty }
+    end
+  end
+
+  describe '#invalid_headers?' do
+    context 'when the headers are invalid' do
+      let(:path) { invalid_headers }
+
+      it { is_expected.to be_invalid_headers }
+    end
+
+    context 'when the headers are valid' do
+      let(:path) { full_not_required }
+
+      it { is_expected.to_not be_invalid_headers }
+    end
+  end
+
+  describe '#header_errors' do
+    let(:path) { invalid_headers }
+
+    its(:header_errors) do
+      is_expected.
+        to eq ['CSV header alternate_name is required, but is missing.']
+    end
+  end
+
+  describe '#required_files' do
+    let(:path) { '/organizations.csv' }
+
+    its(:required_files) do
+      is_expected.
+        to eq %w(organizations.csv locations.csv addresses.csv services.csv
+                 phones.csv)
+    end
+  end
+
+  describe '#validate' do
+    context 'when file is required but missing' do
+      let(:path) { required_but_missing }
+
+      it 'aborts and displays a message' do
+        allow_any_instance_of(Kernel).to receive(:abort).
+          with('Aborting because services.csv is required, but is missing or empty.')
+
+        checker.validate
+      end
+    end
+
+    context 'when file is required but empty' do
+      let(:path) { required_but_empty }
+
+      it 'aborts and displays a message' do
+        allow_any_instance_of(Kernel).to receive(:abort).
+          with('Aborting because services.csv is required, but is missing or empty.')
+
+        checker.validate
+      end
+    end
+
+    context 'when file has invalid headers' do
+      let(:path) { invalid_headers }
+
+      it 'displays missing header message, then aborts with message' do
+        allow_any_instance_of(IO).to receive(:puts).
+          with('CSV header alternate_name is required, but is missing.')
+
+        allow_any_instance_of(Kernel).to receive(:abort).
+          with('invalid_program_headers.csv was not imported. Please fix the headers and try again.')
+
+        checker.validate
+      end
+    end
+  end
+end

--- a/spec/lib/holiday_schedule_importer_spec.rb
+++ b/spec/lib/holiday_schedule_importer_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe HolidayScheduleImporter do
-  let(:invalid_header_content) { Rails.root.join('spec/support/fixtures/invalid_holiday_schedule_headers.csv').read }
   let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_holiday_schedule.csv').read }
   let(:invalid_date) { Rails.root.join('spec/support/fixtures/hs_with_invalid_date.csv').read }
   let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_location_holiday_schedule.csv').read }
@@ -21,29 +20,9 @@ describe HolidayScheduleImporter do
 
   subject(:importer) { HolidayScheduleImporter.new(content) }
 
-  describe '#valid_headers?' do
-    context 'when the holiday_schedule headers are invalid' do
-      let(:content) { invalid_header_content }
-
-      it { is_expected.not_to be_valid_headers }
-    end
-
-    context 'when the headers are valid' do
-      let(:content) { valid_content }
-
-      it { is_expected.to be_valid_headers }
-    end
-  end
-
   describe '#valid?' do
     context 'when the holiday_schedule content is invalid' do
       let(:content) { invalid_content }
-
-      it { is_expected.not_to be_valid }
-    end
-
-    context 'when the holiday_schedule headers are invalid' do
-      let(:content) { invalid_header_content }
 
       it { is_expected.not_to be_valid }
     end
@@ -56,18 +35,6 @@ describe HolidayScheduleImporter do
   end
 
   describe '#errors' do
-    context 'when the holiday_schedule headers are invalid' do
-      let(:content) { invalid_header_content }
-
-      its(:errors) { is_expected.to include('closed column is missing') }
-    end
-
-    context 'when the headers are valid' do
-      let(:content) { valid_content }
-
-      its(:errors) { is_expected.to be_empty }
-    end
-
     context 'when the holiday_schedule content is not valid' do
       let(:content) { invalid_content }
 
@@ -187,6 +154,18 @@ describe HolidayScheduleImporter do
   end
 
   describe '.check_and_import_file' do
+    it 'calls FileChecker' do
+      path = Rails.root.join('spec/support/fixtures/valid_location_holiday_schedule.csv')
+
+      file = double('FileChecker')
+      allow(file).to receive(:validate).and_return true
+
+      expect(FileChecker).to receive(:new).
+        with(path, HolidayScheduleImporter.required_headers).and_return(file)
+
+      HolidayScheduleImporter.check_and_import_file(path)
+    end
+
     context 'with valid data' do
       it 'creates a holiday_schedule' do
         expect do
@@ -205,23 +184,13 @@ describe HolidayScheduleImporter do
         end.not_to change(HolidaySchedule, :count)
       end
     end
+  end
 
-    context 'when file is missing but required' do
-      it 'raises an error' do
-        path = Rails.root.join('spec/support/data/holiday_schedules.csv')
-        expect do
-          HolidayScheduleImporter.check_and_import_file(path)
-        end.to raise_error(/missing or empty/)
-      end
-    end
-
-    context 'when file is empty and required' do
-      it 'raises an error' do
-        expect do
-          path = Rails.root.join('spec/support/fixtures/holiday_schedules.csv')
-          HolidayScheduleImporter.check_and_import_file(path)
-        end.to raise_error(/missing or empty/)
-      end
+  describe '.required_headers' do
+    it 'matches required headers in Wiki' do
+      expect(HolidayScheduleImporter.required_headers).
+        to eq %w(id location_id service_id closed start_date end_date opens_at
+                 closes_at)
     end
   end
 end

--- a/spec/lib/phone_importer_spec.rb
+++ b/spec/lib/phone_importer_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe PhoneImporter do
-  let(:invalid_header_content) { Rails.root.join('spec/support/fixtures/invalid_phone_headers.csv').read }
   let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_phone.csv').read }
   let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_location_phone.csv').read }
   let(:valid_service_phone) { Rails.root.join('spec/support/fixtures/valid_service_phone.csv').read }
@@ -20,29 +19,9 @@ describe PhoneImporter do
 
   subject(:importer) { PhoneImporter.new(content) }
 
-  describe '#valid_headers?' do
-    context 'when the phone headers are invalid' do
-      let(:content) { invalid_header_content }
-
-      it { is_expected.not_to be_valid_headers }
-    end
-
-    context 'when the headers are valid' do
-      let(:content) { valid_content }
-
-      it { is_expected.to be_valid_headers }
-    end
-  end
-
   describe '#valid?' do
     context 'when the phone content is invalid' do
       let(:content) { invalid_content }
-
-      it { is_expected.not_to be_valid }
-    end
-
-    context 'when the phone headers are invalid' do
-      let(:content) { invalid_header_content }
 
       it { is_expected.not_to be_valid }
     end
@@ -55,18 +34,6 @@ describe PhoneImporter do
   end
 
   describe '#errors' do
-    context 'when the phone headers are invalid' do
-      let(:content) { invalid_header_content }
-
-      its(:errors) { is_expected.to include('number_type column is missing') }
-    end
-
-    context 'when the headers are valid' do
-      let(:content) { valid_content }
-
-      its(:errors) { is_expected.to be_empty }
-    end
-
     context 'when the phone content is not valid' do
       let(:content) { invalid_content }
 
@@ -181,6 +148,18 @@ describe PhoneImporter do
   end
 
   describe '.check_and_import_file' do
+    it 'calls FileChecker' do
+      path = Rails.root.join('spec/support/fixtures/valid_location_phone.csv')
+
+      file = double('FileChecker')
+      allow(file).to receive(:validate).and_return true
+
+      expect(FileChecker).to receive(:new).
+        with(path, PhoneImporter.required_headers).and_return(file)
+
+      PhoneImporter.check_and_import_file(path)
+    end
+
     context 'with valid data' do
       it 'creates a phone' do
         expect do
@@ -199,23 +178,13 @@ describe PhoneImporter do
         end.not_to change(Phone, :count)
       end
     end
+  end
 
-    context 'when file is missing but required' do
-      it 'raises an error' do
-        expect do
-          path = Rails.root.join('spec/support/data/phones.csv')
-          PhoneImporter.check_and_import_file(path)
-        end.to raise_error(/missing or empty/)
-      end
-    end
-
-    context 'when file is empty and required' do
-      it 'raises an error' do
-        expect do
-          path = Rails.root.join('spec/support/fixtures/phones.csv')
-          PhoneImporter.check_and_import_file(path)
-        end.to raise_error(/missing or empty/)
-      end
+  describe '.required_headers' do
+    it 'matches required headers in Wiki' do
+      expect(PhoneImporter.required_headers).
+        to eq %w(id location_id organization_id service_id contact_id department
+                 extension number number_type vanity_number country_prefix)
     end
   end
 end

--- a/spec/lib/regular_schedule_importer_spec.rb
+++ b/spec/lib/regular_schedule_importer_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe RegularScheduleImporter do
-  let(:invalid_header_content) { Rails.root.join('spec/support/fixtures/invalid_regular_schedule_headers.csv').read }
   let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_regular_schedule.csv').read }
   let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_location_regular_schedule.csv').read }
   let(:valid_service_regular_schedule) { Rails.root.join('spec/support/fixtures/valid_service_regular_schedule.csv').read }
@@ -18,29 +17,9 @@ describe RegularScheduleImporter do
 
   subject(:importer) { RegularScheduleImporter.new(content) }
 
-  describe '#valid_headers?' do
-    context 'when the regular_schedule headers are invalid' do
-      let(:content) { invalid_header_content }
-
-      it { is_expected.not_to be_valid_headers }
-    end
-
-    context 'when the headers are valid' do
-      let(:content) { valid_content }
-
-      it { is_expected.to be_valid_headers }
-    end
-  end
-
   describe '#valid?' do
     context 'when the regular_schedule content is invalid' do
       let(:content) { invalid_content }
-
-      it { is_expected.not_to be_valid }
-    end
-
-    context 'when the regular_schedule headers are invalid' do
-      let(:content) { invalid_header_content }
 
       it { is_expected.not_to be_valid }
     end
@@ -53,18 +32,6 @@ describe RegularScheduleImporter do
   end
 
   describe '#errors' do
-    context 'when the regular_schedule headers are invalid' do
-      let(:content) { invalid_header_content }
-
-      its(:errors) { is_expected.to include('closes_at column is missing') }
-    end
-
-    context 'when the headers are valid' do
-      let(:content) { valid_content }
-
-      its(:errors) { is_expected.to be_empty }
-    end
-
     context 'when the regular_schedule content is not valid' do
       let(:content) { invalid_content }
 
@@ -148,6 +115,18 @@ describe RegularScheduleImporter do
   end
 
   describe '.check_and_import_file' do
+    it 'calls FileChecker' do
+      path = Rails.root.join('spec/support/fixtures/valid_location_regular_schedule.csv')
+
+      file = double('FileChecker')
+      allow(file).to receive(:validate).and_return true
+
+      expect(FileChecker).to receive(:new).
+        with(path, RegularScheduleImporter.required_headers).and_return(file)
+
+      RegularScheduleImporter.check_and_import_file(path)
+    end
+
     context 'with valid data' do
       it 'creates a regular_schedule' do
         expect do
@@ -166,23 +145,12 @@ describe RegularScheduleImporter do
         end.not_to change(RegularSchedule, :count)
       end
     end
+  end
 
-    context 'when file is missing but required' do
-      it 'raises an error' do
-        expect do
-          path = Rails.root.join('spec/support/data/regular_schedules.csv')
-          RegularScheduleImporter.check_and_import_file(path)
-        end.to raise_error(/missing or empty/)
-      end
-    end
-
-    context 'when file is empty and required' do
-      it 'raises an error' do
-        expect do
-          path = Rails.root.join('spec/support/fixtures/regular_schedules.csv')
-          RegularScheduleImporter.check_and_import_file(path)
-        end.to raise_error(/missing or empty/)
-      end
+  describe '.required_headers' do
+    it 'matches required headers in Wiki' do
+      expect(RegularScheduleImporter.required_headers).
+        to eq %w(id location_id service_id weekday opens_at closes_at)
     end
   end
 end

--- a/spec/support/fixtures/addresses.csv
+++ b/spec/support/fixtures/addresses.csv
@@ -1,1 +1,0 @@
-id,location_id,address_1,address_2,city,state_province,postal_code,country

--- a/spec/support/fixtures/contacts.csv
+++ b/spec/support/fixtures/contacts.csv
@@ -1,1 +1,0 @@
-id,location_id,organization_id,service_id,title,email,department

--- a/spec/support/fixtures/holiday_schedules.csv
+++ b/spec/support/fixtures/holiday_schedules.csv
@@ -1,1 +1,0 @@
-id,location_id,service_id,start_date,end_date,closed,opens_at,closes_at

--- a/spec/support/fixtures/invalid_category_headers.csv
+++ b/spec/support/fixtures/invalid_category_headers.csv
@@ -1,2 +1,0 @@
-taxonomy_id,name,parent_name
-101,Emergency,,

--- a/spec/support/fixtures/invalid_contact_headers.csv
+++ b/spec/support/fixtures/invalid_contact_headers.csv
@@ -1,2 +1,0 @@
-id,location_id,organization_id,service_id,title,email,department
-1,1,,,John Smith,Food Pantry Manager,john@example.org,Food Pantry

--- a/spec/support/fixtures/invalid_holiday_schedule_headers.csv
+++ b/spec/support/fixtures/invalid_holiday_schedule_headers.csv
@@ -1,2 +1,0 @@
-id,location_id,service_id,start_date,end_date,opens_at,closes_at
-1,1,,12/24/2014,12/24/2014,TRUE,,

--- a/spec/support/fixtures/invalid_location_headers.csv
+++ b/spec/support/fixtures/invalid_location_headers.csv
@@ -1,2 +1,0 @@
-id,organization_id,accessibility,admin_emails,alternate_name,description,email,languages,latitude,longitude,transportation,virtual,website
-1,1,,,,The Palo Alto location of the Harvest Food Bank distributes canned goods only.,,,37.7726402,-122.4099154,Harvest Food Bank of Palo Alto,,,

--- a/spec/support/fixtures/invalid_mail_address_headers.csv
+++ b/spec/support/fixtures/invalid_mail_address_headers.csv
@@ -1,2 +1,0 @@
-id,location_id,attention,address_2,city,state_province,postal_code,country
-1,1,John Smith,Suite 101,Fairfax,VA,22031,US

--- a/spec/support/fixtures/invalid_org_headers.csv
+++ b/spec/support/fixtures/invalid_org_headers.csv
@@ -1,2 +1,0 @@
-id,accreditations,alternate_name,date_incorporated,description,email,funding_sources,legal_status,licenses,tax_id,tax_status,website
-1,"BBB, State Board of Education",HFB,1/1/1970,"Harvest Food Bank provides fresh produce, dairy, and canned goods to food pantries throughout the city.",info@example.org,"Donations, Grants",Nonprofit,State Health Inspection License,12-456789,501(c)3,http://www.example.org

--- a/spec/support/fixtures/invalid_phone_headers.csv
+++ b/spec/support/fixtures/invalid_phone_headers.csv
@@ -1,3 +1,0 @@
-id,contact_id,location_id,organization_id,service_id,number,extension,department,vanity_number,country_prefix
-1,,1,,,703-555-1212,123,Food Pantry,voice,703-555-FOOD,1
-2,1,,,,202-555-1212,,,fax,,

--- a/spec/support/fixtures/invalid_regular_schedule_headers.csv
+++ b/spec/support/fixtures/invalid_regular_schedule_headers.csv
@@ -1,6 +1,0 @@
-id,location_id,service_id,weekday,opens_at
-1,1,,Monday,9:30,5:00 PM
-2,1,,Tuesday,9:30,5:00 PM
-3,1,,Wednesday,9:30,5:00 PM
-4,1,,Thursday,9:30,5:00 PM
-5,1,,Friday,9:00,4:00 PM

--- a/spec/support/fixtures/invalid_service_headers.csv
+++ b/spec/support/fixtures/invalid_service_headers.csv
@@ -1,2 +1,0 @@
-id,location_id,program_id,accepted_payments,alternate_name,description,eligibility,email,fees,funding_sources,application_process,keywords,languages,required_documents,service_areas,status,wait_time,website
-1,1,,"Cash, Check, Credit Card",,Provides free hot meals to the homeless.,Homeless and low-income residents.,info@service.org,,"DC Government, Donations",Call or apply in person,"hot meels, hungry","English, Spanish, Tagalog",Harvest Food Bank of Palo Alto,,"San Mateo County, East Palo Alto",active,No wait.,http://example.org/service

--- a/spec/support/fixtures/locations.csv
+++ b/spec/support/fixtures/locations.csv
@@ -1,1 +1,4 @@
 id,organization_id,accessibility,admin_emails,alternate_name,description,email,languages,latitude,longitude,name,transportation,virtual,website
+1,1,"disabled_parking, elevator, wheelchair","admin@example.org, john@example.org",,The Palo Alto location of the Harvest Food Bank distributes canned goods only.,info@location.org,"English, Spanish, Tagalog",37.7726402,-122.4099154,Harvest Food Bank of Palo Alto,,,http://www.example.org
+2,1,"disabled_parking, elevator, wheelchair","admin@example.org, john@example.org",,The Belmont location of the Harvest Food Bank distributes canned goods only.,info@location.org,"English, Spanish, Tagalog",,,Harvest Food Bank of Belmont,SAMTrans 1 block away,,http://www.example.org
+3,2,,,,The Atherton location of the Harvest Food Bank distributes canned goods only.,info@location.org,,,,Harvest Food Bank of Atherton,SAMTrans stops 1 block away,true,http://www.example.org

--- a/spec/support/fixtures/mail_addresses.csv
+++ b/spec/support/fixtures/mail_addresses.csv
@@ -1,1 +1,0 @@
-id,location_id,attention,address_1,address_2,city,state_province,postal_code,country

--- a/spec/support/fixtures/organizations.csv
+++ b/spec/support/fixtures/organizations.csv
@@ -1,1 +1,0 @@
-id,accreditations,alternate_name,date_incorporated,description,email,funding_sources,legal_status,licenses,name,tax_id,tax_status,website

--- a/spec/support/fixtures/phones.csv
+++ b/spec/support/fixtures/phones.csv
@@ -1,1 +1,0 @@
-id,contact_id,location_id,organization_id,service_id,number,extension,department,number_type,vanity_number,country_prefix

--- a/spec/support/fixtures/programs.csv
+++ b/spec/support/fixtures/programs.csv
@@ -1,1 +1,2 @@
 id,organization_id,name,alternate_name
+1,1,Defeat Hunger,

--- a/spec/support/fixtures/regular_schedules.csv
+++ b/spec/support/fixtures/regular_schedules.csv
@@ -1,1 +1,0 @@
-id,location_id,service_id,weekday,opens_at,closes_at


### PR DESCRIPTION
Based on user feedback, the error message for missing CSV headers didn't clearly inform the user that the file was not imported at all.

In this commit, I moved the CSV header validation to the FileChecker class, since the purpose of that class is to verify that the files themselves are valid.

The error messages now specify that CSV headers are required but missing, and that the file was not imported. The import is now aborted if a required file is missing or empty, or if the headers are invalid.

Closes #332.