### PR TITLE
Disable email delivery during rake db:seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,39 +9,48 @@
 
 # Set up test users for the Developer Portal.
 puts 'Setting up first test user...'
-user = User.create! name: 'First User',
+user = User.new name: 'First User',
                     email: 'user@example.com',
                     password: 'mong01dtest',
                     password_confirmation: 'mong01dtest'
+user.skip_confirmation!
+user.save
 user.confirm!
 
 puts 'Setting up second test user...'
-user2 = User.create! name: 'Second User',
+user2 = User.new name: 'Second User',
                      email: 'user2@example.com',
                      password: 'mong01dtest',
                      password_confirmation: 'mong01dtest'
+user2.skip_confirmation!
+user2.save
 user2.confirm!
 
 # Set up test users for the Admin Interface.
 puts 'Setting up first test admin...'
-admin = Admin.create! :name => 'admin with custom domain name',
+admin = Admin.new :name => 'admin with custom domain name',
                     :email => 'ohana@samaritanhouse.com',
                     :password => 'ohanatest',
                     :password_confirmation => 'ohanatest'
+admin.skip_confirmation!
+admin.save
 admin.confirm!
 
 puts 'Setting up second test admin...'
-admin2 = Admin.create! :name => 'admin with generic email',
+admin2 = Admin.new :name => 'admin with generic email',
                      :email => 'ohana@gmail.com',
                      :password => 'ohanatest',
                      :password_confirmation => 'ohanatest'
+admin2.skip_confirmation!
+admin2.save
 admin2.confirm!
 
 puts 'Setting up test super admin...'
-admin3 = Admin.create! :name => 'Super Admin',
+admin3 = Admin.new :name => 'Super Admin',
                      :email => 'masteradmin@ohanapi.org',
                      :password => 'ohanatest',
                      :password_confirmation => 'ohanatest'
-admin3.confirm!
+admin3.skip_confirmation!
 admin3.super_admin = true
 admin3.save
+admin3.confirm!


### PR DESCRIPTION
Because we are using the letter_opener gem, every time an email gets sent, a new browser tab is opened. While testing and resetting the DB, having browser tabs open each time and steal focus from the Terminal gets annoying.

We're not testing or using emails during the seeding of the DB, so we can suppress emails by using Devise's `skip_confirmation!` method.