### PR TITLE
Conditionally validate presence of state_province

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -6,14 +6,11 @@ class Address < ActiveRecord::Base
 
   validates :address_1,
             :city,
-            :state_province,
             :postal_code,
             :country,
             presence: { message: I18n.t('errors.messages.blank_for_address') }
 
-  validates :state_province,
-            presence: { message: I18n.t('errors.messages.blank_for_address') },
-            state_province: true
+  validates :state_province, state_province: true
 
   validates :country, length: { maximum: 2, minimum: 2 }
 

--- a/app/models/mail_address.rb
+++ b/app/models/mail_address.rb
@@ -6,15 +6,12 @@ class MailAddress < ActiveRecord::Base
 
   validates :address_1,
             :city,
-            :state_province,
             :postal_code,
             :country,
             :location,
             presence: { message: I18n.t('errors.messages.blank_for_mail_address') }
 
-  validates :state_province,
-            presence: { message: I18n.t('errors.messages.blank_for_address') },
-            state_province: true
+  validates :state_province, state_province: true
 
   validates :country, length: { maximum: 2, minimum: 2 }
 

--- a/app/validators/state_province_validator.rb
+++ b/app/validators/state_province_validator.rb
@@ -2,11 +2,10 @@ class StateProvinceValidator < ActiveModel::EachValidator
   COUNTRIES_NEEDING_VALIDATION = %w(US CA).freeze
 
   def validate_each(record, attribute, value)
-    return if value.blank?
     return unless COUNTRIES_NEEDING_VALIDATION.include?(record.country)
     default_message = I18n.t('errors.messages.invalid_state_province')
 
-    unless value.size == 2
+    unless value.present? && value.size == 2
       record.errors[attribute] << (options[:message] || default_message)
     end
   end

--- a/spec/features/admin/locations/update_address_spec.rb
+++ b/spec/features/admin/locations/update_address_spec.rb
@@ -55,7 +55,7 @@ feature "Updating a location's address with invalid values" do
     update_street_address(address_1: '123', city: 'fair', state_province: '',
                           postal_code: '12345', country: 'US')
     click_button 'Save changes'
-    expect(page).to have_content "State can't be blank for Address"
+    expect(page).to have_content t('errors.messages.invalid_state_province')
   end
 
   scenario 'with an empty zip' do

--- a/spec/features/admin/locations/update_mail_address_spec.rb
+++ b/spec/features/admin/locations/update_mail_address_spec.rb
@@ -73,7 +73,7 @@ feature 'Updating mailing address with invalid values' do
     update_mailing_address(address_1: '123', city: 'fair', state_province: '',
                            postal_code: '12345', country: 'US')
     click_button 'Save changes'
-    expect(page).to have_content "State can't be blank for Mail Address"
+    expect(page).to have_content t('errors.messages.invalid_state_province')
   end
 
   scenario 'with an empty zip' do

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -16,7 +16,10 @@ describe Address do
 
   it { is_expected.to validate_presence_of(:address_1).with_message("can't be blank for Address") }
   it { is_expected.to validate_presence_of(:city).with_message("can't be blank for Address") }
-  it { is_expected.to validate_presence_of(:state_province).with_message("can't be blank for Address") }
+  it do
+    is_expected.to validate_presence_of(:state_province).
+      with_message(t('errors.messages.invalid_state_province'))
+  end
   it { is_expected.to validate_presence_of(:postal_code).with_message("can't be blank for Address") }
   it { is_expected.to validate_presence_of(:country).with_message("can't be blank for Address") }
 
@@ -93,12 +96,11 @@ describe Address do
     end
 
     context 'when country is not CA or US' do
-      it 'validates presence' do
-        address = build(:address, country: 'UK', state_province: '')
+      it 'does not validate presence' do
+        address = build(:address, country: 'ES', state_province: '')
         address.save
 
-        expect(address.errors[:state_province].first).
-          to eq t('errors.messages.blank_for_address')
+        expect(address.errors[:state_province]).to be_empty
       end
     end
   end

--- a/spec/models/mail_address_spec.rb
+++ b/spec/models/mail_address_spec.rb
@@ -17,7 +17,10 @@ describe MailAddress do
 
   it { is_expected.to validate_presence_of(:address_1).with_message("can't be blank for Mail Address") }
   it { is_expected.to validate_presence_of(:city).with_message("can't be blank for Mail Address") }
-  it { is_expected.to validate_presence_of(:state_province).with_message("can't be blank for Mail Address") }
+  it do
+    is_expected.to validate_presence_of(:state_province).
+      with_message(t('errors.messages.invalid_state_province'))
+  end
   it { is_expected.to validate_presence_of(:postal_code).with_message("can't be blank for Mail Address") }
   it { is_expected.to validate_presence_of(:country).with_message("can't be blank for Mail Address") }
 
@@ -87,12 +90,11 @@ describe MailAddress do
     end
 
     context 'when country is not CA or US' do
-      it 'validates presence' do
+      it 'does not validate presence' do
         mail_address = build(:mail_address, country: 'UK', state_province: '')
         mail_address.save
 
-        expect(mail_address.errors[:state_province].first).
-          to eq t('errors.messages.blank_for_mail_address')
+        expect(mail_address.errors[:state_province]).to be_empty
       end
     end
   end


### PR DESCRIPTION
Not all countries have states or provinces, and not all countries that have them require them in postal addresses. For now, the app only requires them for the US and Canada.