### PR TITLE
Fix various issues with import script.

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -110,12 +110,9 @@ class Location < ActiveRecord::Base
   end
 
   def needs_geocoding?
-    return false if address.blank? || new_record_with_coordinates?
-    address.changed?
-  end
-
-  def new_record_with_coordinates?
-    new_record? && latitude.present? && longitude.present?
+    return false if address.blank? || address.marked_for_destruction?
+    return true if latitude.blank? && longitude.blank?
+    address.changed? && !address.new_record?
   end
 
   # See app/models/concerns/search.rb

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -37,9 +37,14 @@ class Organization < ActiveRecord::Base
   extend FriendlyId
   friendly_id :name, use: [:history]
 
-  after_save :touch_locations, if: :name_changed?
+  after_save :touch_locations, if: :needs_touch?
 
   private
+
+  def needs_touch?
+    return false if locations.count == 0
+    name_changed?
+  end
 
   def touch_locations
     locations.find_each(&:touch)

--- a/lib/category_importer.rb
+++ b/lib/category_importer.rb
@@ -8,7 +8,7 @@ class CategoryImporter < EntityImporter
   end
 
   def import
-    categories.each(&:save!) if valid?
+    categories.each(&:save)
   end
 
   protected

--- a/lib/contact_importer.rb
+++ b/lib/contact_importer.rb
@@ -8,7 +8,7 @@ class ContactImporter < EntityImporter
   end
 
   def import
-    contacts.each(&:save!) if valid?
+    contacts.each(&:save)
   end
 
   protected

--- a/lib/entity_importer.rb
+++ b/lib/entity_importer.rb
@@ -7,9 +7,12 @@ EntityImporter = Struct.new(:content) do
   end
 
   def self.check_and_import_file(path)
-    FileChecker.new(path, required_headers).validate
+    check = FileChecker.new(path, required_headers).validate
 
-    process_import(path)
+    if check != 'skip import'
+      Kernel.puts("\n===> Importing #{path.to_s.split('/').last}")
+      process_import(path)
+    end
   end
 
   def self.process_import(path)

--- a/lib/file_checker.rb
+++ b/lib/file_checker.rb
@@ -5,6 +5,7 @@ class FileChecker
   end
 
   def validate
+    return 'skip import' if missing_or_empty_but_not_required?
     if missing_or_empty?
       abort "Aborting because #{filename} is required, but is missing or empty."
     elsif invalid_headers?
@@ -21,16 +22,24 @@ class FileChecker
     !File.file?(@path)
   end
 
+  def empty?
+    csv_entries.all?(&:blank?)
+  end
+
   def required_but_missing?
     required? && missing?
   end
 
   def required_but_empty?
-    required? && csv_entries.blank?
+    required? && empty?
   end
 
   def missing_or_empty?
     required_but_missing? || required_but_empty?
+  end
+
+  def missing_or_empty_but_not_required?
+    !required? && (missing? || empty?)
   end
 
   def invalid_headers?

--- a/lib/holiday_schedule_importer.rb
+++ b/lib/holiday_schedule_importer.rb
@@ -8,7 +8,7 @@ class HolidayScheduleImporter < EntityImporter
   end
 
   def import
-    holiday_schedules.each(&:save!) if valid?
+    holiday_schedules.each(&:save)
   end
 
   protected

--- a/lib/location_importer.rb
+++ b/lib/location_importer.rb
@@ -30,9 +30,8 @@ LocationImporter = Struct.new(:content, :addresses) do
   end
 
   def import
-    return unless valid?
     locations.each do |location|
-      location.save!
+      location.save
       # Slows down the geocoding. See INSTALL.md for more details.
       sleep ENV['sleep'].to_i if ENV['sleep'].present?
     end
@@ -41,7 +40,7 @@ LocationImporter = Struct.new(:content, :addresses) do
   protected
 
   def locations
-    csv_entries.map(&:to_hash).map do |p|
+    @locations ||= csv_entries.map(&:to_hash).map do |p|
       LocationPresenter.new(p, addresses).to_location
     end
   end

--- a/lib/location_presenter.rb
+++ b/lib/location_presenter.rb
@@ -4,21 +4,29 @@ include ParentAssigner
 LocationPresenter = Struct.new(:row, :addresses) do
   def to_location
     location = Location.find_or_initialize_by(id: row[:id].to_i)
-    transform_fields(row)
+    transform_fields(location, row)
     location.attributes = row
     assign_parents_for(location, row)
     location
   end
 
-  def transform_fields(row)
+  def transform_fields(location, row)
     to_array(row, :accessibility, :admin_emails, :languages)
     row[:virtual] = false if row[:virtual].blank?
-    assign_address_attributes(row)
+    assign_address_attributes(location, row)
   end
 
-  def assign_address_attributes(row)
+  def assign_address_attributes(location, row)
     return if row[:virtual] == true || matching_address(row[:id]).blank?
-    row[:address_attributes] = address_attributes_for(row[:id])
+    if location.address.blank?
+      row[:address_attributes] = address_attributes_for(row[:id])
+    else
+      update_address_for(location)
+    end
+  end
+
+  def update_address_for(location)
+    location.address.update(address_attributes_for(row[:id]))
   end
 
   def address_attributes_for(id)

--- a/lib/mail_address_importer.rb
+++ b/lib/mail_address_importer.rb
@@ -8,7 +8,7 @@ class MailAddressImporter < EntityImporter
   end
 
   def import
-    mail_addresses.each(&:save!) if valid?
+    mail_addresses.each(&:save)
   end
 
   protected

--- a/lib/organization_importer.rb
+++ b/lib/organization_importer.rb
@@ -8,13 +8,13 @@ class OrganizationImporter < EntityImporter
   end
 
   def import
-    organizations.each(&:save!) if valid?
+    organizations.each(&:save)
   end
 
   protected
 
   def organizations
-    csv_entries.map(&:to_hash).map do |p|
+    @organizations ||= csv_entries.map(&:to_hash).map do |p|
       OrganizationPresenter.new(p).to_org
     end
   end

--- a/lib/organization_presenter.rb
+++ b/lib/organization_presenter.rb
@@ -5,6 +5,7 @@ OrganizationPresenter = Struct.new(:row) do
     org = Organization.find_or_initialize_by(id: row[:id].to_i)
     to_array(row, :accreditations, :licenses, :funding_sources)
     org.attributes = row
+    org.id = row[:id].to_i
     org
   end
 end

--- a/lib/parent_assigner.rb
+++ b/lib/parent_assigner.rb
@@ -9,6 +9,6 @@ module ParentAssigner
   end
 
   def foreign_keys_in(row)
-    row.keys.select { |key| key.to_s.include?('_id') }
+    row.keys.select { |key| key.to_s == 'id' || key.to_s.include?('_id') }
   end
 end

--- a/lib/phone_importer.rb
+++ b/lib/phone_importer.rb
@@ -8,7 +8,7 @@ class PhoneImporter < EntityImporter
   end
 
   def import
-    phones.each(&:save!) if valid?
+    phones.each(&:save)
   end
 
   protected

--- a/lib/program_importer.rb
+++ b/lib/program_importer.rb
@@ -8,7 +8,7 @@ class ProgramImporter < EntityImporter
   end
 
   def import
-    programs.each(&:save!) if valid?
+    programs.each(&:save)
   end
 
   protected

--- a/lib/regular_schedule_importer.rb
+++ b/lib/regular_schedule_importer.rb
@@ -8,7 +8,7 @@ class RegularScheduleImporter < EntityImporter
   end
 
   def import
-    regular_schedules.each(&:save!) if valid?
+    regular_schedules.each(&:save)
   end
 
   protected

--- a/lib/service_importer.rb
+++ b/lib/service_importer.rb
@@ -8,7 +8,7 @@ class ServiceImporter < EntityImporter
   end
 
   def import
-    services.each(&:save!) if valid?
+    services.each(&:save)
   end
 
   protected

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -5,21 +5,19 @@ namespace :import do
 
   desc 'Imports organizations'
   task :organizations, [:path] => :environment do |_, args|
-    Kernel.puts('...Importing your organizations...')
     args.with_defaults(path: Rails.root.join('data/organizations.csv'))
     OrganizationImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports programs'
   task :programs, [:path] => :environment do |_, args|
-    Kernel.puts('...Importing your programs...')
     args.with_defaults(path: Rails.root.join('data/programs.csv'))
     ProgramImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports locations'
   task :locations, [:path, :addresses_path] => :environment do |_, args|
-    Kernel.puts('...Importing your locations and addresses...')
+    Kernel.puts("\n===> Importing locations.csv and addresses.csv")
     args.with_defaults(
       path: Rails.root.join('data/locations.csv'),
       addresses_path: Rails.root.join('data/addresses.csv')
@@ -29,49 +27,42 @@ namespace :import do
 
   desc 'Imports taxonomy'
   task :taxonomy, [:path] => :environment do |_, args|
-    Kernel.puts('...Importing your taxonomy...')
     args.with_defaults(path: Rails.root.join('data/taxonomy.csv'))
     CategoryImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports services'
   task :services, [:path] => :environment do |_, args|
-    Kernel.puts('...Importing your services...')
     args.with_defaults(path: Rails.root.join('data/services.csv'))
     ServiceImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports mail addresses'
   task :mail_addresses, [:path] => :environment do |_, args|
-    Kernel.puts('...Importing your mail addresses...')
     args.with_defaults(path: Rails.root.join('data/mail_addresses.csv'))
     MailAddressImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports contacts'
   task :contacts, [:path] => :environment do |_, args|
-    Kernel.puts('...Importing your contacts...')
     args.with_defaults(path: Rails.root.join('data/contacts.csv'))
     ContactImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports phones'
   task :phones, [:path] => :environment do |_, args|
-    Kernel.puts('...Importing your phones...')
     args.with_defaults(path: Rails.root.join('data/phones.csv'))
     PhoneImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports regular_schedules'
   task :regular_schedules, [:path] => :environment do |_, args|
-    Kernel.puts('...Importing your regular_schedules...')
     args.with_defaults(path: Rails.root.join('data/regular_schedules.csv'))
     RegularScheduleImporter.check_and_import_file(args[:path])
   end
 
   desc 'Imports holiday_schedules'
   task :holiday_schedules, [:path] => :environment do |_, args|
-    Kernel.puts('...Importing your holiday_schedules...')
     args.with_defaults(path: Rails.root.join('data/holiday_schedules.csv'))
     HolidayScheduleImporter.check_and_import_file(args[:path])
   end

--- a/spec/lib/address_extractor_spec.rb
+++ b/spec/lib/address_extractor_spec.rb
@@ -6,7 +6,7 @@ describe AddressExtractor do
       it 'extracts the addresses' do
         address_hash = {
           id: '1',
-          location_id: '1',
+          location_id: '2',
           address_1: '123 Main Street',
           address_2: 'Suite 101',
           city: 'Fairfax',
@@ -14,9 +14,14 @@ describe AddressExtractor do
           postal_code: '22031',
           country: 'US'
         }
+        addresses = [
+          address_hash,
+          address_hash.merge(id: '2', location_id: '3'),
+          address_hash.merge(id: '4', location_id: '1')
+        ]
 
         path = Rails.root.join('spec/support/fixtures/valid_address.csv')
-        expect(AddressExtractor.extract_addresses(path)).to eq [address_hash]
+        expect(AddressExtractor.extract_addresses(path)).to eq addresses
       end
     end
 
@@ -34,7 +39,10 @@ describe AddressExtractor do
         }
 
         path = Rails.root.join('spec/support/fixtures/invalid_address.csv')
-        expect(AddressExtractor.extract_addresses(path)).to eq [address_hash]
+        expect(AddressExtractor.extract_addresses(path)).
+          to eq [address_hash,
+                 address_hash.merge(id: '2', location_id: '2', city: 'Fairfax')
+                ]
       end
     end
   end

--- a/spec/lib/file_checker_spec.rb
+++ b/spec/lib/file_checker_spec.rb
@@ -155,6 +155,22 @@ describe FileChecker do
       end
     end
 
+    context 'when file is missing but not required' do
+      let(:path) { missing_not_required }
+
+      it 'returns skip prompt' do
+        expect(checker.validate).to eq 'skip import'
+      end
+    end
+
+    context 'when file is empty but not required' do
+      let(:path) { empty_not_required }
+
+      it 'returns skip prompt' do
+        expect(checker.validate).to eq 'skip import'
+      end
+    end
+
     context 'when file is required but empty' do
       let(:path) { required_but_empty }
 

--- a/spec/lib/service_importer_spec.rb
+++ b/spec/lib/service_importer_spec.rb
@@ -145,28 +145,25 @@ describe ServiceImporter do
       file = double('FileChecker')
       allow(file).to receive(:validate).and_return true
 
+      expect(Kernel).to receive(:puts).
+        with("\n===> Importing valid_service.csv")
+
       expect(FileChecker).to receive(:new).
         with(path, ServiceImporter.required_headers).and_return(file)
 
       ServiceImporter.check_and_import_file(path)
     end
 
-    context 'with valid data' do
-      it 'creates a service' do
-        expect do
-          path = Rails.root.join('spec/support/fixtures/valid_service.csv')
-          ServiceImporter.check_and_import_file(path)
-        end.to change(Service, :count)
-      end
-    end
-
     context 'with invalid data' do
-      it 'does not create a service' do
-        allow_any_instance_of(IO).to receive(:puts)
-        expect do
-          path = Rails.root.join('spec/support/fixtures/invalid_service.csv')
-          ServiceImporter.check_and_import_file(path)
-        end.not_to change(Service, :count)
+      it 'outputs error message' do
+        expect(Kernel).to receive(:puts).
+          with("\n===> Importing invalid_service.csv")
+
+        expect(Kernel).to receive(:puts).
+          with("Line 2: Name can't be blank for Service")
+
+        path = Rails.root.join('spec/support/fixtures/invalid_service.csv')
+        ServiceImporter.check_and_import_file(path)
       end
     end
   end

--- a/spec/lib/service_presenter_spec.rb
+++ b/spec/lib/service_presenter_spec.rb
@@ -153,5 +153,21 @@ describe ServicePresenter do
         expect(service.attributes['service_areas']).to eq []
       end
     end
+
+    context 'ids are not sequential' do
+      let(:properties) do
+        {
+          location_id: '1',
+          id: '2',
+          name: 'Example Service',
+          description: 'Example description'
+        }
+      end
+
+      it 'sets id to the id in the CSV' do
+        service = presenter.to_service
+        expect(service.id).to eq 2
+      end
+    end
   end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -171,9 +171,39 @@ describe Location do
     before(:each) { @loc = create(:location) }
 
     it "doesn't geocode when address hasn't changed" do
-      @loc.update(name: 'new name')
+      @loc.name = 'new name'
       expect(@loc).not_to receive(:geocode)
       @loc.save!
+    end
+
+    it "doesn't geocode when location is new and has coordinates" do
+      loc = build(:location_with_admin)
+      expect(loc).not_to receive(:geocode)
+      loc.save!
+    end
+
+    it "doesn't geocode when location is virtual and has coordinates" do
+      loc = build(:location_with_admin, virtual: true)
+      expect(loc).not_to receive(:geocode)
+      loc.save!
+    end
+
+    it "doesn't geocode when location has coordinates but no address" do
+      loc = build(:no_address, latitude: 37.5808591, longitude: -122.343072)
+      expect(loc).not_to receive(:geocode)
+      loc.save!
+    end
+
+    it "doesn't geocode when location has neither address nor coordinates" do
+      org = create(:nearby_org)
+      loc = Location.new(
+        name: 'foo',
+        description: 'bar',
+        virtual: true
+      )
+      loc.organization_id = org.id
+      expect(loc).not_to receive(:geocode)
+      loc.save!
     end
 
     it 'geocodes when address has changed' do
@@ -187,13 +217,45 @@ describe Location do
       expect(@loc.reload.latitude).to_not eq(coords.second)
     end
 
+    it 'does not geocode when address is added to location with coords' do
+      loc = create(:no_address, latitude: 37.5808591, longitude: -122.343072)
+
+      expect(loc).to_not receive(:geocode)
+
+      loc.update!(address_attributes: attributes_for(:address))
+    end
+
+    it 'geocodes when address is added to virtual location that did not have one' do
+      loc = create(:no_address)
+      expect(loc.latitude).to be_nil
+
+      loc.update!(address_attributes: attributes_for(:address))
+
+      expect(loc.reload.latitude).to be_present
+    end
+
+    it 'geocodes when location is new, has an address, but no coordinates' do
+      org = create(:nearby_org)
+      loc = Location.new(
+        name: 'foo',
+        description: 'bar',
+        address_attributes: attributes_for(:address)
+      )
+      loc.organization_id = org.id
+
+      expect(loc).to receive(:geocode)
+
+      loc.save
+    end
+
     it 'resets coordinates when address is removed' do
-      @loc.update(
+      expect(@loc).not_to receive(:geocode)
+
+      @loc.update!(
         virtual: true,
         address_attributes: { id: @loc.address.id, _destroy: '1' }
       )
-      expect(@loc).not_to receive(:geocode)
-      @loc.save!
+
       expect(@loc.reload.latitude).to be_nil
       expect(@loc.reload.longitude).to be_nil
     end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -105,4 +105,36 @@ describe Organization do
       end
     end
   end
+
+  describe 'touching locations' do
+    context 'when does not have locations' do
+      it 'does not touch locations' do
+        org = build(:organization)
+
+        expect(org).to_not receive(:touch_locations)
+
+        org.save
+      end
+    end
+
+    context 'when name has not changed' do
+      it 'does not touch locations' do
+        org = create(:location).organization
+
+        expect(org).to_not receive(:touch_locations)
+
+        org.update(description: 'foo')
+      end
+    end
+
+    context 'when name has changed and org has locations' do
+      it 'touches locations' do
+        org = create(:location).organization
+
+        expect(org).to receive(:touch_locations)
+
+        org.update(name: 'foo')
+      end
+    end
+  end
 end

--- a/spec/support/fixtures/invalid_address.csv
+++ b/spec/support/fixtures/invalid_address.csv
@@ -1,2 +1,3 @@
 id,location_id,address_1,address_2,city,state_province,postal_code,country
 1,1,123 Main Street,Suite 101,,VA,22031,US
+2,2,123 Main Street,Suite 101,Fairfax,VA,22031,US

--- a/spec/support/fixtures/invalid_category.csv
+++ b/spec/support/fixtures/invalid_category.csv
@@ -1,2 +1,3 @@
 taxonomy_id,name,parent_id,parent_name
 101-01,,,
+102,Food,,

--- a/spec/support/fixtures/invalid_contact.csv
+++ b/spec/support/fixtures/invalid_contact.csv
@@ -1,2 +1,3 @@
 id,location_id,organization_id,service_id,name,title,email,department
 1,1,,,,Food Pantry Manager,john@example.org,Food Pantry
+2,,1,,Jane Doe,Food Pantry Manager,jane@example.org,Food Pantry

--- a/spec/support/fixtures/invalid_holiday_schedule.csv
+++ b/spec/support/fixtures/invalid_holiday_schedule.csv
@@ -1,2 +1,3 @@
 id,location_id,service_id,start_date,end_date,closed,opens_at,closes_at
 1,1,,12/24/2014,12/24/2014,,9:30,
+3,1,,11/27/2014,11/27/2014,FALSE,10:00,3:00 PM

--- a/spec/support/fixtures/invalid_location.csv
+++ b/spec/support/fixtures/invalid_location.csv
@@ -1,2 +1,3 @@
 id,organization_id,accessibility,admin_emails,alternate_name,description,email,languages,latitude,longitude,name,transportation,virtual,website
 1,1,"disabled_parking, elevator, wheelchair","admin@example.org, john@example.org",,The Palo Alto location of the Harvest Food Bank distributes canned goods only.,info@location.org,"English, Spanish, Tagalog",37.7726402,-122.4099154,,,,http://www.example.org
+3,1,,,,The Atherton location of the Harvest Food Bank distributes canned goods only.,info@location.org,,,,Harvest Food Bank of Atherton,SAMTrans stops 1 block away,false,http://www.example.org

--- a/spec/support/fixtures/invalid_mail_address.csv
+++ b/spec/support/fixtures/invalid_mail_address.csv
@@ -1,2 +1,3 @@
 id,location_id,attention,address_1,address_2,city,state_province,postal_code,country
 1,1,John Smith,,Suite 101,Fairfax,VA,22031,US
+2,1,John Smith,123 Main Street,Suite 101,Fairfax,VA,22031,US

--- a/spec/support/fixtures/invalid_org.csv
+++ b/spec/support/fixtures/invalid_org.csv
@@ -1,2 +1,3 @@
 id,accreditations,alternate_name,date_incorporated,description,email,funding_sources,legal_status,licenses,name,tax_id,tax_status,website
 1,"BBB, State Board of Education",HFB,1/1/1970,"Harvest Food Bank provides fresh produce, dairy, and canned goods to food pantries throughout the city.",info@example.org,"Donations, Grants",Nonprofit,State Health Inspection License,,12-456789,501(c)3,http://www.example.org
+2,,,1/2/2014,Example org description,info@fakeorg.org,Donations,Nonprofit,,Example Agency,,,http://www.example.org

--- a/spec/support/fixtures/invalid_phone.csv
+++ b/spec/support/fixtures/invalid_phone.csv
@@ -1,2 +1,3 @@
 id,contact_id,location_id,organization_id,service_id,number,extension,department,number_type,vanity_number,country_prefix
 1,,1,,,703-555-1212,123,Food Pantry,,703-555-FOOD,1
+2,,1,,,202-555-1212,,,fax,,

--- a/spec/support/fixtures/invalid_program.csv
+++ b/spec/support/fixtures/invalid_program.csv
@@ -1,2 +1,3 @@
 id,organization_id,name,alternate_name
 1,1,,
+2,1,Foo,

--- a/spec/support/fixtures/valid_address.csv
+++ b/spec/support/fixtures/valid_address.csv
@@ -1,2 +1,4 @@
 id,location_id,address_1,address_2,city,state_province,postal_code,country
-1,1,123 Main Street,Suite 101,Fairfax,VA,22031,US
+1,2,123 Main Street,Suite 101,Fairfax,VA,22031,US
+2,3,123 Main Street,Suite 101,Fairfax,VA,22031,US
+4,1,123 Main Street,Suite 101,Fairfax,VA,22031,US

--- a/spec/support/fixtures/valid_location_contact.csv
+++ b/spec/support/fixtures/valid_location_contact.csv
@@ -1,2 +1,2 @@
 id,location_id,organization_id,service_id,name,title,email,department
-1,1,,,John Smith,Food Pantry Manager,john@example.org,Food Pantry
+2,1,,,John Smith,Food Pantry Manager,john@example.org,Food Pantry

--- a/spec/support/fixtures/valid_location_holiday_schedule.csv
+++ b/spec/support/fixtures/valid_location_holiday_schedule.csv
@@ -1,2 +1,2 @@
 id,location_id,service_id,start_date,end_date,closed,opens_at,closes_at
-1,1,,1/11/2014,11/27/2014,FALSE,10:00,3:00 PM
+2,1,,1/11/2014,11/27/2014,FALSE,10:00,3:00 PM

--- a/spec/support/fixtures/valid_location_phone.csv
+++ b/spec/support/fixtures/valid_location_phone.csv
@@ -1,2 +1,2 @@
 id,contact_id,location_id,organization_id,service_id,number,extension,department,number_type,vanity_number,country_prefix
-1,,1,,,703-555-1212,123,Food Pantry,voice,703-555-FOOD,1
+2,,1,,,703-555-1212,123,Food Pantry,voice,703-555-FOOD,1

--- a/spec/support/fixtures/valid_location_regular_schedule.csv
+++ b/spec/support/fixtures/valid_location_regular_schedule.csv
@@ -1,2 +1,2 @@
 id,location_id,service_id,weekday,opens_at,closes_at
-1,1,,Monday,9:30,5:00 PM
+2,1,,Monday,9:30,5:00 PM

--- a/spec/support/fixtures/valid_mail_address.csv
+++ b/spec/support/fixtures/valid_mail_address.csv
@@ -1,2 +1,2 @@
 id,location_id,attention,address_1,address_2,city,state_province,postal_code,country
-1,1,John Smith,123 Main Street,Suite 101,Fairfax,VA,22031,US
+2,1,John Smith,123 Main Street,Suite 101,Fairfax,VA,22031,US

--- a/spec/support/fixtures/valid_org.csv
+++ b/spec/support/fixtures/valid_org.csv
@@ -1,2 +1,2 @@
 id,accreditations,alternate_name,date_incorporated,description,email,funding_sources,legal_status,licenses,name,tax_id,tax_status,website
-1,"BBB, State Board of Education",HFB,1/2/1970,"Harvest Food Bank provides fresh produce, dairy, and canned goods to food pantries throughout the city.",info@example.org,"Donations, Grants",Nonprofit,State Health Inspection License,Parent Agency,12-456789,501(c)3,http://www.example.org
+2,"BBB, State Board of Education",HFB,1/2/1970,"Harvest Food Bank provides fresh produce, dairy, and canned goods to food pantries throughout the city.",info@example.org,"Donations, Grants",Nonprofit,State Health Inspection License,Parent Agency,12-456789,501(c)3,http://www.example.org

--- a/spec/support/fixtures/valid_program.csv
+++ b/spec/support/fixtures/valid_program.csv
@@ -1,2 +1,2 @@
 id,organization_id,name,alternate_name
-1,1,Defeat Hunger,
+2,1,Defeat Hunger,


### PR DESCRIPTION
- Improve logic that determines whether or not a location needs to be geocoded. In addition, the location importer now checks to see if an address already exists for the location. If so, it updates that same address instead of assigning address attributes, which, unbeknown to me, actually destroyed the existing address and created a new one. The side effect of destroying the address is that it triggered the `reset_location_coordinates` callback, which in turn triggered the geocoding since the location no longer had coordinates.

- Invalid entries no longer prevent the entire CSV file from being saved to the database. Now, valid entries get saved, and error messages are displayed for invalid entries.

- If a CSV file doesn't have sequential IDs, the database will now save the entry with the same ID as in the CSV file. Previously, the database would assign sequential IDs, which would cause mismatches between CSV files that refer to a particular foreign key.

- Added a conditional for the `touch_locations` callback in organization.rb to improve performance during initial import of organizations.

- The console output that lets you know which file is being imported has been moved out of the rake task and into the EntityImporter. That way, if a file is skipped (because it's not required and is missing or empty, for example), then the console won't say that it is being imported.

Closes #336.