### PR TITLE
Provide one-click download of CSV files as a zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ dump.rdb
 # Ignore test-related files
 /coverage.data
 /coverage/
-.rspec
 
 # CIP data
 /data/cip_mvp.json

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,8 @@ gem 'kgio'
 gem 'memcachier'
 
 gem 'csv_shaper'
+gem 'rubyzip'
+gem 'sucker_punch'
 
 group :production do
   # Heroku recommended
@@ -80,6 +82,7 @@ group :test do
   gem 'coveralls', require: false
   gem 'rubocop'
   gem 'haml-lint'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
     cliver (0.3.2)
     coderay (1.1.0)
     coffee-rails (4.1.0)
@@ -85,6 +87,8 @@ GEM
       simplecov (~> 0.10.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     csv_shaper (1.1.1)
       activesupport (>= 3.0.0)
     dalli (2.7.4)
@@ -131,6 +135,7 @@ GEM
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
     hike (1.2.3)
+    hitimes (1.2.2)
     html2haml (2.0.0)
       erubis (~> 2.7.0)
       haml (~> 4.0.0)
@@ -267,6 +272,8 @@ GEM
     ruby-progressbar (1.7.5)
     ruby_parser (3.6.5)
       sexp_processor (~> 4.1)
+    rubyzip (1.1.7)
+    safe_yaml (1.0.4)
     sass (3.4.13)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -299,12 +306,16 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    sucker_punch (1.4.0)
+      celluloid (~> 0.16.0)
     sysexits (1.2.0)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
+    timers (4.0.1)
+      hitimes
     tins (1.5.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -317,6 +328,9 @@ GEM
     uniform_notifier (1.9.0)
     warden (1.2.3)
       rack (>= 1.0)
+    webmock (1.21.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
     websocket-driver (0.5.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -367,10 +381,13 @@ DEPENDENCIES
   rspec-its
   rspec-rails (~> 3.1)
   rubocop
+  rubyzip
   sass-rails (~> 5.0)
   select2-rails
   shoulda-matchers
   spring
   spring-commands-rspec
   spring-watcher-listen
+  sucker_punch
   uglifier (>= 1.3.0)
+  webmock

--- a/app/controllers/admin/csv_controller.rb
+++ b/app/controllers/admin/csv_controller.rb
@@ -1,7 +1,5 @@
 class Admin
   class CsvController < ApplicationController
-    before_action :set_filename
-
     # The CSV content for each action is defined in
     # app/views/admin/csv/{action_name}.csv.shaper
 
@@ -35,10 +33,41 @@ class Admin
     def services
     end
 
+    def all
+      redirect_to :back,
+                  notice: 'Your zip file is being generated. Please refresh ' \
+                  "the page in a few seconds. Once it's ready, " \
+                  'the button at the bottom will change from ' \
+                  "'Generate zip file' to 'Download zip file'."
+      ZipDownloadJob.new.async.later(2, tmp_file_name, url_prefix)
+    end
+
+    def download_zip
+      if File.exist?(tmp_file_name)
+        send_file tmp_file_name,
+                  type: 'application/zip',
+                  filename: zip_file_name,
+                  x_sendfile: true
+
+        ZipDeleteJob.new.async.later(60, tmp_file_name)
+      else
+        redirect_to admin_dashboard_url,
+                    notice: 'Please wait while the zip file is being generated'
+      end
+    end
+
     private
 
-    def set_filename
-      @filename = "All #{action_name} - #{Time.zone.today.to_formatted_s}.csv"
+    def tmp_file_name
+      @tmp_file_name ||= "#{Rails.root}/tmp/archive.zip"
+    end
+
+    def zip_file_name
+      "archive-#{Time.zone.today.to_formatted_s}.zip"
+    end
+
+    def url_prefix
+      @url_prefix ||= "#{admin_dashboard_url(subdomain: ENV['ADMIN_SUBDOMAIN'])}/csv/"
     end
   end
 end

--- a/app/controllers/admin/csv_controller.rb
+++ b/app/controllers/admin/csv_controller.rb
@@ -35,10 +35,7 @@ class Admin
 
     def all
       redirect_to :back,
-                  notice: 'Your zip file is being generated. Please refresh ' \
-                  "the page in a few seconds. Once it's ready, " \
-                  'the button at the bottom will change from ' \
-                  "'Generate zip file' to 'Download zip file'."
+                  notice: I18n.t('admin.notices.zip_file_generation')
       ZipDownloadJob.new.async.later(2, tmp_file_name, url_prefix)
     end
 
@@ -52,7 +49,7 @@ class Admin
         ZipDeleteJob.new.async.later(60, tmp_file_name)
       else
         redirect_to admin_dashboard_url,
-                    notice: 'Please wait while the zip file is being generated'
+                    notice: I18n.t('admin.notices.wait_for_zip_file')
       end
     end
 

--- a/app/helpers/admin/zip_download_helper.rb
+++ b/app/helpers/admin/zip_download_helper.rb
@@ -1,0 +1,15 @@
+class Admin
+  module ZipDownloadHelper
+    def zip_file_status
+      if File.exist?(tmp_file_name)
+        link_to 'Download zip file', admin_csv_download_zip_url, class: 'btn btn-primary'
+      else
+        link_to 'Generate zip file', admin_csv_all_path, class: 'btn btn-primary'
+      end
+    end
+
+    def tmp_file_name
+      "#{Rails.root}/tmp/archive.zip"
+    end
+  end
+end

--- a/app/helpers/admin/zip_download_helper.rb
+++ b/app/helpers/admin/zip_download_helper.rb
@@ -2,9 +2,9 @@ class Admin
   module ZipDownloadHelper
     def zip_file_status
       if File.exist?(tmp_file_name)
-        link_to 'Download zip file', admin_csv_download_zip_url, class: 'btn btn-primary'
+        link_to I18n.t('admin.buttons.download_zip_file'), admin_csv_download_zip_url, class: 'btn btn-primary'
       else
-        link_to 'Generate zip file', admin_csv_all_path, class: 'btn btn-primary'
+        link_to I18n.t('admin.buttons.generate_zip_file'), admin_csv_all_path, class: 'btn btn-primary'
       end
     end
 

--- a/app/jobs/zip_delete_job.rb
+++ b/app/jobs/zip_delete_job.rb
@@ -1,0 +1,11 @@
+class ZipDeleteJob
+  include SuckerPunch::Job
+
+  def perform(file)
+    File.delete(file)
+  end
+
+  def later(sec, file)
+    after(sec) { perform(file) }
+  end
+end

--- a/app/jobs/zip_download_job.rb
+++ b/app/jobs/zip_download_job.rb
@@ -1,0 +1,15 @@
+require 'csv_downloader'
+
+class ZipDownloadJob
+  include SuckerPunch::Job
+
+  def perform(tmp_file_name, url_prefix)
+    ActiveRecord::Base.connection_pool.with_connection do
+      CsvDownloader.new(tmp_file_name, url_prefix).create_zip_archive
+    end
+  end
+
+  def later(sec, tmp_file_name, url_prefix)
+    after(sec) { perform(tmp_file_name, url_prefix) }
+  end
+end

--- a/app/views/admin/csv/holiday_schedules.csv.shaper
+++ b/app/views/admin/csv/holiday_schedules.csv.shaper
@@ -2,8 +2,7 @@ csv.headers :id, :location_id, :service_id, :start_date, :end_date, :closed,
             :opens_at, :closes_at
 
 csv.rows HolidaySchedule.find_each do |csv, hs|
-  csv.cells :id, :location_id, :service_id, :start_date, :end_date, :closed,
-            :opens_at, :closes_at
+  csv.cells :id, :location_id, :service_id, :closed
 
   csv.cell :start_date, hs.start_date.strftime('%B %d, %Y')
   csv.cell :end_date, hs.end_date.strftime('%B %d, %Y')

--- a/app/views/admin/csv/locations.csv.shaper
+++ b/app/views/admin/csv/locations.csv.shaper
@@ -4,8 +4,7 @@ csv.headers :id, :organization_id, :accessibility, :admin_emails,
             :website, :virtual
 
 csv.rows Location.find_each do |csv, location|
-  csv.cells :id, :organization_id, :accessibility, :admin_emails,
-            :alternate_name, :description, :email, :languages,
+  csv.cells :id, :organization_id, :alternate_name, :description, :email,
             :latitude, :longitude, :name, :short_desc, :transportation,
             :website, :virtual
 

--- a/app/views/admin/csv/organizations.csv.shaper
+++ b/app/views/admin/csv/organizations.csv.shaper
@@ -3,9 +3,8 @@ csv.headers :id, :accreditations, :alternate_name, :date_incorporated,
             :name, :tax_id, :tax_status, :website
 
 csv.rows Organization.find_each do |csv, org|
-  csv.cells :id, :accreditations, :alternate_name, :date_incorporated,
-            :description, :email, :funding_sources, :legal_status, :licenses,
-            :name, :tax_id, :tax_status, :website
+  csv.cells :id, :alternate_name, :description, :email, :legal_status, :name,
+            :tax_id, :tax_status, :website
 
   csv.cell :accreditations, org.accreditations.try(:join, ', ')
   csv.cell :date_incorporated, org.date_incorporated.try(:strftime, '%B %d, %Y')

--- a/app/views/admin/csv/regular_schedules.csv.shaper
+++ b/app/views/admin/csv/regular_schedules.csv.shaper
@@ -1,9 +1,9 @@
 csv.headers :id, :location_id, :service_id, :weekday, :opens_at, :closes_at
 
 csv.rows RegularSchedule.find_each do |csv, rs|
-  csv.cells :id, :location_id, :service_id, :weekday, :opens_at, :closes_at
+  csv.cells :id, :location_id, :service_id
 
+  csv.cell :weekday, rs.weekday == 7 ? 'Sunday' : Date::DAYNAMES[rs.weekday]
   csv.cell :opens_at, rs.opens_at.strftime('%H:%M')
   csv.cell :closes_at, rs.closes_at.strftime('%H:%M')
-  csv.cell :weekday, rs.weekday == 7 ? 'Sunday' : Date::DAYNAMES[rs.weekday]
 end

--- a/app/views/admin/csv/services.csv.shaper
+++ b/app/views/admin/csv/services.csv.shaper
@@ -6,12 +6,10 @@ csv.headers :id, :location_id, :program_id, :accepted_payments,
             :taxonomy_ids
 
 csv.rows Service.find_each do |csv, service|
-  csv.cells :id, :location_id, :program_id, :accepted_payments,
-            :alternate_name, :application_process, :audience, :description,
-            :eligibility, :email, :fees, :funding_sources,
-            :interpretation_services, :keywords, :languages, :name,
-            :required_documents, :service_areas, :status, :wait_time, :website,
-            :category_ids
+  csv.cells :id, :location_id, :program_id, :alternate_name,
+            :application_process, :audience, :description, :eligibility,
+            :email, :fees, :interpretation_services, :name, :status,
+            :wait_time, :website
 
   csv.cell :accepted_payments, service.accepted_payments.try(:join, ', ')
   csv.cell :funding_sources, service.funding_sources.try(:join, ', ')

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -21,16 +21,8 @@
 
   - if current_admin.super_admin?
     %h2 CSV Downloads
-    %p= link_to 'Download all addresses as CSV', admin_csv_addresses_path, class: 'btn btn-primary'
-    %p= link_to 'Download all contacts as CSV', admin_csv_contacts_path, class: 'btn btn-primary'
-    %p= link_to 'Download all holiday schedules as CSV', admin_csv_holiday_schedules_path, class: 'btn btn-primary'
-    %p= link_to 'Download all locations as CSV', admin_csv_locations_path, class: 'btn btn-primary'
-    %p= link_to 'Download all mail addresses as CSV', admin_csv_mail_addresses_path, class: 'btn btn-primary'
-    %p= link_to 'Download all organizations as CSV', admin_csv_organizations_path, class: 'btn btn-primary'
-    %p= link_to 'Download all phones as CSV', admin_csv_phones_path, class: 'btn btn-primary'
-    %p= link_to 'Download all programs as CSV', admin_csv_programs_path, class: 'btn btn-primary'
-    %p= link_to 'Download all regular schedules as CSV', admin_csv_regular_schedules_path, class: 'btn btn-primary'
-    %p= link_to 'Download all services as CSV', admin_csv_services_path, class: 'btn btn-primary'
+
+    %p= zip_file_status
 
     %hr
     Ohana API #{link_to "v#{version}", 'https://github.com/codeforamerica/ohana-api/blob/master/CHANGELOG.md'}

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,5 +60,7 @@ module OhanaApi
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.active_job.queue_adapter = :sucker_punch
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,7 +28,16 @@ en:
         state_province: 'State'
   admin:
     api_location: 'San Mateo County'
+    buttons:
+      download_zip_file: 'Download zip file'
+      generate_zip_file: 'Generate zip file'
     not_authorized: 'You are not authorized to perform this action.'
+    notices:
+      zip_file_generation: >
+        Your zip file is being generated. Please refresh the page in a few
+        seconds. Once it's ready, the button at the bottom will change from
+        'Generate zip file' to 'Download zip file'.
+      wait_for_zip_file: 'Please wait while the zip file is being generated.'
 
   enumerize:
     location:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
       resources :programs, except: :show
       resources :services, only: :index
 
-      namespace :csv, defaults: { format: 'csv' } do
+      namespace :csv do
         get 'addresses'
         get 'contacts'
         get 'holiday_schedules'
@@ -38,6 +38,8 @@ Rails.application.routes.draw do
         get 'programs'
         get 'regular_schedules'
         get 'services'
+        get 'all'
+        get 'download_zip'
       end
 
       get 'locations/:location_id/services/:id', to: 'services#edit'

--- a/lib/csv_downloader.rb
+++ b/lib/csv_downloader.rb
@@ -1,0 +1,28 @@
+require 'zip'
+require 'open-uri'
+
+class CsvDownloader
+  TABLES = %w(locations addresses mail_addresses contacts holiday_schedules
+              phones programs services regular_schedules organizations).freeze
+
+  def initialize(file, url_prefix)
+    @file = file
+    @url_prefix = url_prefix
+  end
+
+  def create_zip_archive
+    Zip::File.open(@file, Zip::File::CREATE) do |zipfile|
+      TABLES.each do |table|
+        response = open(url_for(table)).read
+
+        zipfile.get_output_stream("#{table}.csv") { |os| os.puts(response) }
+      end
+    end
+  end
+
+  private
+
+  def url_for(table)
+    "#{@url_prefix}#{table}"
+  end
+end

--- a/spec/controllers/admin/csv_controller_spec.rb
+++ b/spec/controllers/admin/csv_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe Admin::CsvController do
+  describe 'GET all' do
+    let(:tmp_file_name) { "#{Rails.root}/tmp/archive.zip" }
+    let(:url_prefix) { 'http://test.host/admin/csv/' }
+
+    it 'performs the ZipDownload job 2 seconds later' do
+      log_in_as_admin(:super_admin)
+
+      request.env['HTTP_REFERER'] = 'http://example.com'
+
+      expect(ZipDownloadJob).to receive_message_chain(:new, :async, :later).
+        with(2, tmp_file_name, url_prefix)
+
+      get :all
+    end
+  end
+
+  describe 'GET download_zip' do
+    let(:tmp_file_name) { "#{Rails.root}/tmp/archive.zip" }
+    let(:zip_file_name) { "archive-#{Time.zone.today.to_formatted_s}.zip" }
+
+    context 'when the file exists' do
+      it 'deletes the file 60 seconds later' do
+        log_in_as_admin(:super_admin)
+
+        allow(File).to receive(:exist?).with(tmp_file_name).and_return true
+
+        expect(controller).to receive(:send_file).
+          with(tmp_file_name,
+               type: 'application/zip',
+               filename: zip_file_name,
+               x_sendfile: true)
+
+        expect(ZipDeleteJob).to receive_message_chain(:new, :async, :later).
+          with(60, tmp_file_name)
+
+        get :download_zip
+      end
+    end
+
+    context 'when the file does not exist' do
+      it 'redirects to admin dashboard' do
+        log_in_as_admin(:super_admin)
+
+        allow(File).to receive(:exist?).with(tmp_file_name).and_return false
+
+        get :download_zip
+
+        expect(response).to redirect_to admin_dashboard_url
+      end
+    end
+  end
+end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -140,8 +140,8 @@ feature 'Admin Home page' do
       expect(page).to_not have_content 'CSV Downloads'
       expect(page).
         to_not have_link(
-          'Download all addresses as CSV',
-          admin_csv_addresses_path)
+          t('admin.buttons.generate_zip_file'),
+          admin_csv_all_path)
     end
   end
 
@@ -183,13 +183,13 @@ feature 'Admin Home page' do
       expect(page).to have_content 'CSV Downloads'
 
       expect(page).
-        to have_link('Generate zip file', admin_csv_all_path)
+        to have_link(t('admin.buttons.generate_zip_file'), admin_csv_all_path)
     end
 
     it 'displays a notice while the zip is being generated' do
-      click_link 'Generate zip file'
+      click_link t('admin.buttons.generate_zip_file')
 
-      expect(page).to have_content 'Your zip file is being generated.'
+      expect(page).to have_content t('admin.notices.zip_file_generation')
     end
 
     it 'changes the button text when the zip is ready' do
@@ -197,7 +197,7 @@ feature 'Admin Home page' do
       allow(File).to receive(:exist?).with(tmp_file_name).and_return true
       visit '/admin'
 
-      expect(page).to have_link 'Download zip file'
+      expect(page).to have_link t('admin.buttons.download_zip_file')
     end
   end
 

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -179,46 +179,25 @@ feature 'Admin Home page' do
       expect(page).to have_link 'Add a new program', new_admin_program_path
     end
 
-    it 'displays links to download CSV files' do
+    it 'displays link to generate zip file' do
       expect(page).to have_content 'CSV Downloads'
 
       expect(page).
-        to have_link('Download all addresses as CSV', admin_csv_addresses_path)
+        to have_link('Generate zip file', admin_csv_all_path)
+    end
 
-      expect(page).
-        to have_link('Download all contacts as CSV', admin_csv_contacts_path)
+    it 'displays a notice while the zip is being generated' do
+      click_link 'Generate zip file'
 
-      expect(page).
-        to have_link(
-          'Download all holiday schedules as CSV',
-          admin_csv_holiday_schedules_path)
+      expect(page).to have_content 'Your zip file is being generated.'
+    end
 
-      expect(page).
-        to have_link('Download all locations as CSV', admin_csv_locations_path)
+    it 'changes the button text when the zip is ready' do
+      tmp_file_name = "#{Rails.root}/tmp/archive.zip"
+      allow(File).to receive(:exist?).with(tmp_file_name).and_return true
+      visit '/admin'
 
-      expect(page).
-        to have_link(
-          'Download all mail addresses as CSV',
-          admin_csv_mail_addresses_path)
-
-      expect(page).
-        to have_link(
-          'Download all organizations as CSV',
-          admin_csv_organizations_path)
-
-      expect(page).
-        to have_link('Download all phones as CSV', admin_csv_phones_path)
-
-      expect(page).
-        to have_link('Download all programs as CSV', admin_csv_programs_path)
-
-      expect(page).
-        to have_link(
-          'Download all regular schedules as CSV',
-          admin_csv_regular_schedules_path)
-
-      expect(page).
-        to have_link('Download all services as CSV', admin_csv_services_path)
+      expect(page).to have_link 'Download zip file'
     end
   end
 

--- a/spec/jobs/zip_delete_job_spec.rb
+++ b/spec/jobs/zip_delete_job_spec.rb
@@ -1,0 +1,11 @@
+describe ZipDeleteJob, job: true do
+  describe '#perform' do
+    let(:file) { 'archive.zip' }
+
+    it 'deletes the file' do
+      expect(File).to receive(:delete).with(file)
+
+      ZipDeleteJob.new.perform(file)
+    end
+  end
+end

--- a/spec/jobs/zip_download_job_spec.rb
+++ b/spec/jobs/zip_download_job_spec.rb
@@ -1,0 +1,20 @@
+require 'webmock/rspec'
+
+describe ZipDownloadJob, job: true do
+  describe '#perform' do
+    let(:tmp_file_name) { 'archive.zip' }
+    let(:url_prefix) { 'http://example.com/admin/csv/' }
+    let(:csv_downloader) { double('CsvDownloader') }
+
+    it 'calls CsvDownloader' do
+      stub_request(:any, /.*example.*/)
+
+      allow(csv_downloader).to receive(:create_zip_archive).and_return true
+
+      expect(CsvDownloader).to receive(:new).with(tmp_file_name, url_prefix).
+        and_return(csv_downloader)
+
+      ZipDownloadJob.new.perform(tmp_file_name, url_prefix)
+    end
+  end
+end

--- a/spec/lib/csv_downloader_spec.rb
+++ b/spec/lib/csv_downloader_spec.rb
@@ -1,0 +1,18 @@
+require 'webmock/rspec'
+
+describe CsvDownloader do
+  describe '#create_zip_archive' do
+    let(:tmp_file_name) { 'tmp/archive.zip' }
+    let(:url_prefix) { 'http://example.com/admin/csv/' }
+
+    after(:each) { File.delete(tmp_file_name) }
+
+    it 'creates a zip file in the tmp_file_name path' do
+      stub_request(:any, /.*example.*/)
+
+      CsvDownloader.new(tmp_file_name, url_prefix).create_zip_archive
+
+      expect(File.exist?(tmp_file_name)).to eq true
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,10 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = :random
 
+  config.after(:suite) do
+    File.delete("#{Rails.root}/tmp/archive.zip")
+  end
+
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,3 @@
+require 'webmock/rspec'
+
+WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
Since large files can take a while to process, the zip file is
prepared in the background so that the user can continue browsing
the site. The background processing is provided via the Sucker Punch
gem, which doesn't require any additional Heroku dependencies such as
Redis.

While the zip file is being generated, the button on the admin
interface reads "Generating zip file", and when it's ready, it reads
"Download zip file".

Once the file has been downloaded, it is deleted from the /tmp folder
a minute later so that a new zip file can be generated at a later time.

The zip file's name contains the date at which it was downloaded to
make it easy to see when the zip was last generated.

I also cleaned up the csv.shaper files to remove duplicated cells.

Closes #326.