### PR TITLE
Allow DATABASE_URL to be used for any enviroment

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -4,6 +4,7 @@ default: &default
   host: localhost
   port: 5432
   pool: <%= ENV['DB_POOL'] || ENV['MAX_THREADS'] || 5 %>
+  url: <%= ENV['DATABASE_URL'] %>
   timeout: 5000
 
 development:


### PR DESCRIPTION
The DATABASE_URL setting will be used if it is present, otherwise the existing defaults are used for development and test.

This change makes it possible for users who aren't using `localhost` for Postgres to configure their database in `config/application.yml`. For example, my Ohana databases live in a Docker container at 192.168.59.103 and require a specific username and password to access.