### PR TITLE
Update deprecated command for Heroku addons

### DIFF
--- a/script/setup_heroku
+++ b/script/setup_heroku
@@ -25,13 +25,13 @@ then
   echo "Getting ready to install add-ons for $herokuApp"
 
   echo "Installing Postgres"
-  heroku addons:add heroku-postgresql --app $herokuApp
+  heroku addons:create heroku-postgresql --app $herokuApp
 
   echo "Installing Mandrill by MailChimp"
-  heroku addons:add mandrill --app $herokuApp
+  heroku addons:create mandrill --app $herokuApp
 
   echo "Installing Memcachier"
-  heroku addons:add memcachier --app $herokuApp
+  heroku addons:create memcachier --app $herokuApp
 
   echo "All done setting up env vars and add-ons."
   echo "Pushing code to Heroku now. This will take a few minutes..."


### PR DESCRIPTION
Was previously getting this warning when running the setup_heroku script: WARNING: `heroku addons:add` has been deprecated. Please use `heroku addons:create` instead. This commit removes the warning.