### PR TITLE
Replace pg_search with activerecord query

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,9 +45,6 @@ gem 'enumerize'
 # App config and ENV variables for heroku
 gem 'figaro', '~> 1.0'
 
-# Search
-gem 'pg_search', '~> 0.7'
-
 # Nested categories for OpenEligibility
 gem 'ancestry'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,10 +175,6 @@ GEM
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
     pg (0.18.2)
-    pg_search (0.7.9)
-      activerecord (>= 3.1)
-      activesupport (>= 3.1)
-      arel
     poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -360,7 +356,6 @@ DEPENDENCIES
   letter_opener
   memcachier
   pg
-  pg_search (~> 0.7)
   poltergeist
   protected_attributes
   puma


### PR DESCRIPTION
Why:

We're only using the pg_search gem for the keyword search, and the query that it generates is not that complicated. Upgrading to the latest version of the pg_search gem breaks our tests. So, instead of having to rely on a third party, we can generate the same query ourselves using activerecord, and reduce our dependencies with the same stone.

How:

To figure out what the proper query was, I fired up the Rails console and ran `Location.keyword('food')`. That gave me the SQL query I needed, which I then converted to activerecord so that the result would return an ActiveRecord::Relation that can be chained with other scopes.