### PR TITLE
Make dashboard_spec more robust

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def version
-    @version ||= File.read('VERSION')
+    @version ||= File.read('VERSION').chomp
   end
 end

--- a/spec/features/admin/dashboard_spec.rb
+++ b/spec/features/admin/dashboard_spec.rb
@@ -202,9 +202,7 @@ feature 'Admin Home page' do
   end
 
   describe 'Ohana API version' do
-    before do
-      allow(File).to receive(:read).with('VERSION').and_return('1.0.0')
-    end
+    let(:version) { File.read('VERSION').chomp }
     let(:prefix) { 'https://github.com/codeforamerica/ohana-api/blob/master/' }
 
     context 'super admin' do
@@ -212,7 +210,7 @@ feature 'Admin Home page' do
         login_super_admin
         visit '/admin'
 
-        expect(page).to have_link 'v1.0.0', href: "#{prefix}CHANGELOG.md"
+        expect(page).to have_link "v#{version}", href: "#{prefix}CHANGELOG.md"
       end
     end
 
@@ -221,7 +219,7 @@ feature 'Admin Home page' do
         login_admin
         visit '/admin'
 
-        expect(page).to_not have_link 'v1.0.0', href: "#{prefix}CHANGELOG.md"
+        expect(page).to_not have_link "v#{version}", href: "#{prefix}CHANGELOG.md"
       end
     end
   end


### PR DESCRIPTION
Why:
Previously, the version test would fail intermittently on Travis because File.read would be called by something else, like a gem.

How:
Explicitly read the VERSION file in the test.