### PR TITLE
Order results by updated_at when rank is the same

### DIFF
--- a/app/models/concerns/search.rb
+++ b/app/models/concerns/search.rb
@@ -30,7 +30,8 @@ module Search
       sanitized = ActiveRecord::Base.sanitize(query)
 
       where("locations.tsv_body @@ plainto_tsquery('english', ?)", query).
-        order("ts_rank(locations.tsv_body, plainto_tsquery('english', #{sanitized})) DESC")
+        order("ts_rank(locations.tsv_body, plainto_tsquery('english', #{sanitized})) DESC,
+              locations.updated_at DESC")
     end
 
     def language(lang)


### PR DESCRIPTION
Why:
Search queries that contain the keyword parameter are ordered by the
rank calculated by the Postgres full text search feature. In some
cases, the rank could be the same for all results, but in those cases,
Postgres does not guarantee that the order will be same all the time.
This will cause issues with pagination since the order might not be
consistent as you go from one page to another.

In order to keep the order consistent, we can specify an additional way
to rank the results. I've chosen to order by most recently updated.