### PR TITLE
Add gems to assist in profiling app performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,4 +90,9 @@ group :development do
   gem 'spring-commands-rspec'
   gem 'spring-watcher-listen'
   gem 'letter_opener'
+
+  # For profiling the app's performance and memory usage.
+  gem 'derailed'
+  gem 'rack-mini-profiler'
+  gem 'flamegraph'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
       execjs
       json
     bcrypt (3.1.10)
+    benchmark-ips (2.3.0)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -94,6 +95,14 @@ GEM
     dalli (2.7.4)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
+    derailed (0.1.0)
+      derailed_benchmarks
+    derailed_benchmarks (1.0.1)
+      benchmark-ips (~> 2)
+      get_process_mem (~> 0)
+      memory_profiler (~> 0)
+      rack (~> 1)
+      rake (~> 10)
     devise (3.5.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -114,12 +123,18 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    fast_stack (0.1.0)
+      rake
+      rake-compiler
     ffi (1.9.10)
     figaro (1.1.1)
       thor (~> 0.14)
+    flamegraph (0.1.0)
+      fast_stack
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
     geocoder (1.2.9)
+    get_process_mem (0.2.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     haml (4.0.6)
@@ -164,6 +179,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     memcachier (0.0.2)
+    memory_profiler (0.9.4)
     mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.8.0)
@@ -192,6 +208,8 @@ GEM
     rack-cache (1.2)
       rack (>= 0.4)
     rack-cors (0.4.0)
+    rack-mini-profiler (0.9.7)
+      rack (>= 1.1.3)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.3)
@@ -225,6 +243,8 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
     rake (10.4.2)
+    rake-compiler (0.9.5)
+      rake
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -342,10 +362,12 @@ DEPENDENCIES
   csv_shaper
   dalli
   database_cleaner (>= 1.0.0.RC1)
+  derailed
   devise (~> 3.4)
   enumerize
   factory_girl_rails (>= 4.2.0)
   figaro (~> 1.0)
+  flamegraph
   friendly_id (~> 5.0)
   geocoder
   haml-lint
@@ -363,6 +385,7 @@ DEPENDENCIES
   quiet_assets (>= 1.0.2)
   rack-cache
   rack-cors
+  rack-mini-profiler
   rails (~> 4.2)
   rails_12factor
   rspec-its


### PR DESCRIPTION
Why:
To allow developers to measure the performance and memory usage of the app.

Further reading:
http://www.nateberkopec.com/2015/08/05/rack-mini-profiler-the-secret-weapon.html

https://github.com/schneems/derailed_benchmarks