### PR TITLE
Eliminate duplicates when using service_area

### DIFF
--- a/spec/api/search/service_area_spec.rb
+++ b/spec/api/search/service_area_spec.rb
@@ -12,11 +12,13 @@ describe "GET 'search'" do
 
     it 'only returns locations with matching service areas' do
       get api_search_index_url(service_area: 'Atherton', subdomain: ENV['API_SUBDOMAIN'])
+
       expect(json.length).to eq 1
     end
 
     it 'does not return locations when no matching service areas exist' do
       get api_search_index_url(service_area: 'Belmont', subdomain: ENV['API_SUBDOMAIN'])
+
       expect(json.length).to eq 0
     end
 
@@ -28,7 +30,27 @@ describe "GET 'search'" do
         location: 'Burlingame',
         subdomain: ENV['API_SUBDOMAIN']
       )
+
       expect(json.length).to eq 1
+    end
+  end
+
+  context 'when location has multiple services' do
+    it 'does not duplicate results when all services match service_area parameter' do
+      location = create(:location)
+      location.services.create!(attributes_for(:service).
+        merge(service_areas: ['Belmont']))
+      location.services.create!(attributes_for(:service).
+        merge(name: 'Second Service', service_areas: ['Belmont']))
+
+      get api_search_index_url(
+        service_area: 'Belmont',
+        keyword: 'jobs',
+        location: 'Burlingame',
+        subdomain: ENV['API_SUBDOMAIN']
+      )
+
+      expect(headers['X-Total-Count']).to eq '1'
     end
   end
 end


### PR DESCRIPTION
When performing a search, if a location has many services that match the `service_area` parameter, the same location will be duplicated in the search results.

To eliminate the duplication, you can either append `.uniq` or `.group('locations.id')` to the `Location#service_area` query. However, both are not without consequences. If the keyword parameter is also present when using `.uniq`, then we need to add a select clause that selects all location columns, as well as the full-text search rank.

If we use `group`, then we get an error when the `location` parameter is present due to the way the geocoder gem works. The issue in this case is caused by the `maximum(:updated_at)` call used in the `cache_key` method in `search_controller`. I couldn't figure out how to make `group` work, so I went with the former.

Closes #357.