### PR TITLE
Optimize import with no_touching and SmarterCSV

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ group :test, :development do
   gem 'rspec-its'
   gem 'factory_girl_rails', '>= 4.2.0'
   gem 'bullet'
+  gem 'smarter_csv'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,6 +302,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    smarter_csv (1.1.0)
     spring (1.3.6)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -395,6 +396,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   select2-rails
   shoulda-matchers
+  smarter_csv
   spring
   spring-commands-rspec
   spring-watcher-listen

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -97,7 +97,7 @@ the JSON response so it is easier to read in the browser.
 
 - From the command line, run `script/reset` to reset the database.
 
-- Run `script/import` to import your CSV files.
+- Run `script/import` to import your CSV files, but first read the notes below.
 
 If your data doesn't already include a taxonomy, and if you want to use the Open
 Eligibility taxonomy, you can create the categories with this command:

--- a/lib/address_extractor.rb
+++ b/lib/address_extractor.rb
@@ -1,16 +1,9 @@
-AddressExtractor = Struct.new(:content) do
+AddressExtractor = Struct.new(:path) do
   def self.extract_addresses(path)
-    content = File.read(path)
-    new(content).addresses
+    new(path).csv_entries
   end
-
-  def addresses
-    @addresses ||= csv_entries.map(&:to_hash)
-  end
-
-  protected
 
   def csv_entries
-    @csv_entries ||= CSV.new(content, headers: true, header_converters: :symbol).entries
+    @csv_entries ||= SmarterCSV.process(path, convert_values_to_numeric: false)
   end
 end

--- a/lib/category_importer.rb
+++ b/lib/category_importer.rb
@@ -8,14 +8,19 @@ class CategoryImporter < EntityImporter
   end
 
   def import
-    categories.each(&:save)
+    ActiveRecord::Base.no_touching do
+      categories.each(&:save)
+    end
   end
 
   protected
 
   def categories
-    @categories ||= csv_entries.map(&:to_hash).map do |p|
-      CategoryPresenter.new(p).to_category
+    @categories ||= csv_entries.inject([]) do |result, chunks|
+      chunks.each do |row|
+        result << CategoryPresenter.new(row).to_category
+      end
+      result
     end
   end
 

--- a/lib/category_presenter.rb
+++ b/lib/category_presenter.rb
@@ -6,8 +6,8 @@ CategoryPresenter = Struct.new(:row) do
   end
 
   def parent_category(row)
-    Category.find_or_create_by(name: row[:parent_name],
-                               taxonomy_id: row[:parent_id])
+    @category ||= Category.find_or_create_by(name: row[:parent_name],
+                                             taxonomy_id: row[:parent_id])
   end
 
   def child_category(row)

--- a/lib/contact_importer.rb
+++ b/lib/contact_importer.rb
@@ -8,14 +8,19 @@ class ContactImporter < EntityImporter
   end
 
   def import
-    contacts.each(&:save)
+    ActiveRecord::Base.no_touching do
+      contacts.each(&:save)
+    end
   end
 
   protected
 
   def contacts
-    @contacts ||= csv_entries.map(&:to_hash).map do |p|
-      ContactPresenter.new(p).to_contact
+    @contacts ||= csv_entries.inject([]) do |result, chunks|
+      chunks.each do |row|
+        result << ContactPresenter.new(row).to_contact
+      end
+      result
     end
   end
 

--- a/lib/entity_importer.rb
+++ b/lib/entity_importer.rb
@@ -1,9 +1,8 @@
 require 'csv'
 
-EntityImporter = Struct.new(:content) do
+EntityImporter = Struct.new(:path) do
   def self.import_file(path)
-    content = File.read(path)
-    new(content).tap(&:import)
+    new(path).tap(&:import)
   end
 
   def self.check_and_import_file(path)
@@ -23,6 +22,6 @@ EntityImporter = Struct.new(:content) do
   protected
 
   def csv_entries
-    @csv_entries ||= CSV.new(content, headers: true, header_converters: :symbol).entries
+    @csv_entries ||= SmarterCSV.process(path, chunk_size: 100)
   end
 end

--- a/lib/file_checker.rb
+++ b/lib/file_checker.rb
@@ -60,16 +60,12 @@ class FileChecker
     %w(organizations.csv locations.csv addresses.csv services.csv phones.csv)
   end
 
-  def content
-    File.read(@path)
-  end
-
   def csv_entries
-    @csv_entries ||= CSV.new(content, headers: true).entries
+    @csv_entries ||= SmarterCSV.process(@path, chunk_size: 100)
   end
 
   def headers
-    @headers ||= csv_entries.first.headers
+    @headers ||= CSV.open(@path, 'r') { |csv| csv.first }.to_a
   end
 
   def missing_headers

--- a/lib/holiday_schedule_importer.rb
+++ b/lib/holiday_schedule_importer.rb
@@ -8,14 +8,19 @@ class HolidayScheduleImporter < EntityImporter
   end
 
   def import
-    holiday_schedules.each(&:save)
+    ActiveRecord::Base.no_touching do
+      holiday_schedules.each(&:save)
+    end
   end
 
   protected
 
   def holiday_schedules
-    @holiday_schedules ||= csv_entries.map(&:to_hash).map do |p|
-      HolidaySchedulePresenter.new(p).to_holiday_schedule
+    @holiday_schedules ||= csv_entries.inject([]) do |result, chunks|
+      chunks.each do |row|
+        result << HolidaySchedulePresenter.new(row).to_holiday_schedule
+      end
+      result
     end
   end
 

--- a/lib/location_importer.rb
+++ b/lib/location_importer.rb
@@ -1,7 +1,6 @@
-LocationImporter = Struct.new(:content, :addresses) do
+LocationImporter = Struct.new(:path, :addresses) do
   def self.import_file(path, addresses_path)
-    content = File.read(path)
-    new(content, addresses_for(addresses_path)).tap(&:import)
+    new(path, addresses_for(addresses_path)).tap(&:import)
   end
 
   def self.check_and_import_file(locations_path, addresses_path)
@@ -30,23 +29,28 @@ LocationImporter = Struct.new(:content, :addresses) do
   end
 
   def import
-    locations.each do |location|
-      location.save
-      # Slows down the geocoding. See INSTALL.md for more details.
-      sleep ENV['sleep'].to_i if ENV['sleep'].present?
+    ActiveRecord::Base.no_touching do
+      locations.each do |location|
+        location.save
+        # Slows down the geocoding. See INSTALL.md for more details.
+        sleep ENV['sleep'].to_i if ENV['sleep'].present?
+      end
     end
   end
 
   protected
 
   def locations
-    @locations ||= csv_entries.map(&:to_hash).map do |p|
-      LocationPresenter.new(p, addresses).to_location
+    @locations ||= csv_entries.inject([]) do |locs, chunks|
+      chunks.each do |row|
+        locs << LocationPresenter.new(row, addresses).to_location
+      end
+      locs
     end
   end
 
   def csv_entries
-    @csv_entries ||= CSV.new(content, headers: true, header_converters: :symbol).entries
+    @csv_entries ||= SmarterCSV.process(path, chunk_size: 100, convert_values_to_numeric: false)
   end
 
   def self.required_headers

--- a/lib/location_presenter.rb
+++ b/lib/location_presenter.rb
@@ -30,10 +30,10 @@ LocationPresenter = Struct.new(:row, :addresses) do
   end
 
   def address_attributes_for(id)
-    matching_address(id).except(:id)
+    @attributes ||= matching_address(id).except(:id)
   end
 
   def matching_address(id)
-    addresses.find { |a| a[:location_id] == id }
+    @matching_address ||= addresses.detect { |a| a[:location_id] == id }
   end
 end

--- a/lib/mail_address_importer.rb
+++ b/lib/mail_address_importer.rb
@@ -8,14 +8,19 @@ class MailAddressImporter < EntityImporter
   end
 
   def import
-    mail_addresses.each(&:save)
+    ActiveRecord::Base.no_touching do
+      mail_addresses.each(&:save)
+    end
   end
 
   protected
 
   def mail_addresses
-    @mail_addresses ||= csv_entries.map(&:to_hash).map do |p|
-      MailAddressPresenter.new(p).to_mail_address
+    @mail_addresses ||= csv_entries.inject([]) do |result, chunks|
+      chunks.each do |row|
+        result << MailAddressPresenter.new(row).to_mail_address
+      end
+      result
     end
   end
 

--- a/lib/organization_importer.rb
+++ b/lib/organization_importer.rb
@@ -8,14 +8,19 @@ class OrganizationImporter < EntityImporter
   end
 
   def import
-    organizations.each(&:save)
+    ActiveRecord::Base.no_touching do
+      organizations.each(&:save)
+    end
   end
 
   protected
 
   def organizations
-    @organizations ||= csv_entries.map(&:to_hash).map do |p|
-      OrganizationPresenter.new(p).to_org
+    @organizations ||= csv_entries.inject([]) do |orgs, chunks|
+      chunks.each do |row|
+        orgs << OrganizationPresenter.new(row).to_org
+      end
+      orgs
     end
   end
 

--- a/lib/phone_importer.rb
+++ b/lib/phone_importer.rb
@@ -8,14 +8,19 @@ class PhoneImporter < EntityImporter
   end
 
   def import
-    phones.each(&:save)
+    ActiveRecord::Base.no_touching do
+      phones.each(&:save)
+    end
   end
 
   protected
 
   def phones
-    @phones ||= csv_entries.map(&:to_hash).map do |p|
-      PhonePresenter.new(p).to_phone
+    @phones ||= csv_entries.inject([]) do |result, chunks|
+      chunks.each do |row|
+        result << PhonePresenter.new(row).to_phone
+      end
+      result
     end
   end
 

--- a/lib/program_importer.rb
+++ b/lib/program_importer.rb
@@ -8,14 +8,19 @@ class ProgramImporter < EntityImporter
   end
 
   def import
-    programs.each(&:save)
+    ActiveRecord::Base.no_touching do
+      programs.each(&:save)
+    end
   end
 
   protected
 
   def programs
-    @programs ||= csv_entries.map(&:to_hash).map do |p|
-      ProgramPresenter.new(p).to_program
+    @programs ||= csv_entries.inject([]) do |result, chunks|
+      chunks.each do |row|
+        result << ProgramPresenter.new(row).to_program
+      end
+      result
     end
   end
 

--- a/lib/regular_schedule_importer.rb
+++ b/lib/regular_schedule_importer.rb
@@ -8,14 +8,19 @@ class RegularScheduleImporter < EntityImporter
   end
 
   def import
-    regular_schedules.each(&:save)
+    ActiveRecord::Base.no_touching do
+      regular_schedules.each(&:save)
+    end
   end
 
   protected
 
   def regular_schedules
-    @regular_schedules ||= csv_entries.map(&:to_hash).map do |p|
-      RegularSchedulePresenter.new(p).to_regular_schedule
+    @regular_schedules ||= csv_entries.inject([]) do |result, chunks|
+      chunks.each do |row|
+        result << RegularSchedulePresenter.new(row).to_regular_schedule
+      end
+      result
     end
   end
 

--- a/lib/service_importer.rb
+++ b/lib/service_importer.rb
@@ -8,14 +8,19 @@ class ServiceImporter < EntityImporter
   end
 
   def import
-    services.each(&:save)
+    ActiveRecord::Base.no_touching do
+      services.each(&:save)
+    end
   end
 
   protected
 
   def services
-    @services ||= csv_entries.map(&:to_hash).map do |p|
-      ServicePresenter.new(p).to_service
+    @services ||= csv_entries.inject([]) do |result, chunks|
+      chunks.each do |row|
+        result << ServicePresenter.new(row).to_service
+      end
+      result
     end
   end
 

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,7 +1,7 @@
 namespace :import do
   task all: [:organizations, :programs, :locations, :taxonomy, :services,
              :mail_addresses, :contacts, :phones, :regular_schedules,
-             :holiday_schedules]
+             :holiday_schedules, :touch_locations]
 
   desc 'Imports organizations'
   task :organizations, [:path] => :environment do |_, args|
@@ -65,5 +65,11 @@ namespace :import do
   task :holiday_schedules, [:path] => :environment do |_, args|
     args.with_defaults(path: Rails.root.join('data/holiday_schedules.csv'))
     HolidayScheduleImporter.check_and_import_file(args[:path])
+  end
+
+  desc 'Touch locations'
+  task :touch_locations, [:path] => :environment do
+    Kernel.puts "\n===> Updating the full-text search index"
+    Location.update_all(updated_at: Time.zone.now)
   end
 end

--- a/spec/lib/address_extractor_spec.rb
+++ b/spec/lib/address_extractor_spec.rb
@@ -32,7 +32,6 @@ describe AddressExtractor do
           location_id: '1',
           address_1: '123 Main Street',
           address_2: 'Suite 101',
-          city: nil,
           state_province: 'VA',
           postal_code: '22031',
           country: 'US'

--- a/spec/lib/category_importer_spec.rb
+++ b/spec/lib/category_importer_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 describe CategoryImporter do
-  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_category.csv').read }
-  let(:invalid_parent) { Rails.root.join('spec/support/fixtures/invalid_parent_category.csv').read }
-  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_category.csv').read }
-  let(:existing_content) { Rails.root.join('spec/support/fixtures/existing_category.csv').read }
+  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_category.csv') }
+  let(:invalid_parent) { Rails.root.join('spec/support/fixtures/invalid_parent_category.csv') }
+  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_category.csv') }
+  let(:existing_content) { Rails.root.join('spec/support/fixtures/existing_category.csv') }
 
   subject(:importer) { CategoryImporter.new(content) }
 

--- a/spec/lib/contact_importer_spec.rb
+++ b/spec/lib/contact_importer_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 describe ContactImporter do
-  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_contact.csv').read }
-  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_location_contact.csv').read }
-  let(:valid_service_contact) { Rails.root.join('spec/support/fixtures/valid_service_contact.csv').read }
-  let(:valid_org_contact) { Rails.root.join('spec/support/fixtures/valid_org_contact.csv').read }
-  let(:no_parent) { Rails.root.join('spec/support/fixtures/contact_with_no_parent.csv').read }
+  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_contact.csv') }
+  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_location_contact.csv') }
+  let(:valid_service_contact) { Rails.root.join('spec/support/fixtures/valid_service_contact.csv') }
+  let(:valid_org_contact) { Rails.root.join('spec/support/fixtures/valid_org_contact.csv') }
+  let(:no_parent) { Rails.root.join('spec/support/fixtures/contact_with_no_parent.csv') }
 
   before(:all) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/lib/holiday_schedule_importer_spec.rb
+++ b/spec/lib/holiday_schedule_importer_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 describe HolidayScheduleImporter do
-  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_holiday_schedule.csv').read }
-  let(:invalid_date) { Rails.root.join('spec/support/fixtures/hs_with_invalid_date.csv').read }
-  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_location_holiday_schedule.csv').read }
-  let(:valid_service_holiday_schedule) { Rails.root.join('spec/support/fixtures/valid_service_holiday_schedule.csv').read }
-  let(:no_parent) { Rails.root.join('spec/support/fixtures/holiday_schedule_with_no_parent.csv').read }
-  let(:spelled_out_date) { Rails.root.join('spec/support/fixtures/hs_with_spelled_out_date.csv').read }
-  let(:org_with_2_digit_year) { Rails.root.join('spec/support/fixtures/hs_with_2_digit_year.csv').read }
+  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_holiday_schedule.csv') }
+  let(:invalid_date) { Rails.root.join('spec/support/fixtures/hs_with_invalid_date.csv') }
+  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_location_holiday_schedule.csv') }
+  let(:valid_service_holiday_schedule) { Rails.root.join('spec/support/fixtures/valid_service_holiday_schedule.csv') }
+  let(:no_parent) { Rails.root.join('spec/support/fixtures/holiday_schedule_with_no_parent.csv') }
+  let(:spelled_out_date) { Rails.root.join('spec/support/fixtures/hs_with_spelled_out_date.csv') }
+  let(:org_with_2_digit_year) { Rails.root.join('spec/support/fixtures/hs_with_2_digit_year.csv') }
 
   before(:all) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/lib/location_importer_spec.rb
+++ b/spec/lib/location_importer_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe LocationImporter do
-  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_location.csv').read }
-  let(:invalid_org) { Rails.root.join('spec/support/fixtures/invalid_location_org.csv').read }
-  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_location.csv').read }
+  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_location.csv') }
+  let(:invalid_org) { Rails.root.join('spec/support/fixtures/invalid_location_org.csv') }
+  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_location.csv') }
 
   let(:valid_address) do
     path = Rails.root.join('spec/support/fixtures/valid_address.csv')

--- a/spec/lib/mail_address_importer_spec.rb
+++ b/spec/lib/mail_address_importer_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe MailAddressImporter do
-  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_mail_address.csv').read }
-  let(:invalid_location) { Rails.root.join('spec/support/fixtures/invalid_mail_address_location.csv').read }
-  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_mail_address.csv').read }
+  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_mail_address.csv') }
+  let(:invalid_location) { Rails.root.join('spec/support/fixtures/invalid_mail_address_location.csv') }
+  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_mail_address.csv') }
 
   before(:all) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/lib/organization_importer_spec.rb
+++ b/spec/lib/organization_importer_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 describe OrganizationImporter do
-  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_org.csv').read }
-  let(:invalid_date) { Rails.root.join('spec/support/fixtures/org_with_invalid_date.csv').read }
-  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_org.csv').read }
-  let(:spelled_out_date) { Rails.root.join('spec/support/fixtures/org_with_spelled_out_date.csv').read }
-  let(:org_with_2_digit_year) { Rails.root.join('spec/support/fixtures/org_with_2_digit_year.csv').read }
+  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_org.csv') }
+  let(:invalid_date) { Rails.root.join('spec/support/fixtures/org_with_invalid_date.csv') }
+  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_org.csv') }
+  let(:spelled_out_date) { Rails.root.join('spec/support/fixtures/org_with_spelled_out_date.csv') }
+  let(:org_with_2_digit_year) { Rails.root.join('spec/support/fixtures/org_with_2_digit_year.csv') }
 
   subject(:importer) { OrganizationImporter.new(content) }
 

--- a/spec/lib/phone_importer_spec.rb
+++ b/spec/lib/phone_importer_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 describe PhoneImporter do
-  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_phone.csv').read }
-  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_location_phone.csv').read }
-  let(:valid_service_phone) { Rails.root.join('spec/support/fixtures/valid_service_phone.csv').read }
-  let(:valid_org_phone) { Rails.root.join('spec/support/fixtures/valid_org_phone.csv').read }
-  let(:valid_contact_phone) { Rails.root.join('spec/support/fixtures/valid_contact_phone.csv').read }
-  let(:no_parent) { Rails.root.join('spec/support/fixtures/phone_with_no_parent.csv').read }
+  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_phone.csv') }
+  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_location_phone.csv') }
+  let(:valid_service_phone) { Rails.root.join('spec/support/fixtures/valid_service_phone.csv') }
+  let(:valid_org_phone) { Rails.root.join('spec/support/fixtures/valid_org_phone.csv') }
+  let(:valid_contact_phone) { Rails.root.join('spec/support/fixtures/valid_contact_phone.csv') }
+  let(:no_parent) { Rails.root.join('spec/support/fixtures/phone_with_no_parent.csv') }
 
   before(:all) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/lib/program_importer_spec.rb
+++ b/spec/lib/program_importer_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe ProgramImporter do
-  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_program.csv').read }
-  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_program.csv').read }
-  let(:no_parent) { Rails.root.join('spec/support/fixtures/program_with_no_parent.csv').read }
+  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_program.csv') }
+  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_program.csv') }
+  let(:no_parent) { Rails.root.join('spec/support/fixtures/program_with_no_parent.csv') }
 
   before(:all) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/lib/regular_schedule_importer_spec.rb
+++ b/spec/lib/regular_schedule_importer_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 describe RegularScheduleImporter do
-  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_regular_schedule.csv').read }
-  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_location_regular_schedule.csv').read }
-  let(:valid_service_regular_schedule) { Rails.root.join('spec/support/fixtures/valid_service_regular_schedule.csv').read }
-  let(:no_parent) { Rails.root.join('spec/support/fixtures/regular_schedule_with_no_parent.csv').read }
+  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_regular_schedule.csv') }
+  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_location_regular_schedule.csv') }
+  let(:valid_service_regular_schedule) { Rails.root.join('spec/support/fixtures/valid_service_regular_schedule.csv') }
+  let(:no_parent) { Rails.root.join('spec/support/fixtures/regular_schedule_with_no_parent.csv') }
 
   before(:all) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/lib/service_importer_spec.rb
+++ b/spec/lib/service_importer_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe ServiceImporter do
-  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_service.csv').read }
-  let(:invalid_location) { Rails.root.join('spec/support/fixtures/invalid_service_location.csv').read }
-  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_service.csv').read }
+  let(:invalid_content) { Rails.root.join('spec/support/fixtures/invalid_service.csv') }
+  let(:invalid_location) { Rails.root.join('spec/support/fixtures/invalid_service_location.csv') }
+  let(:valid_content) { Rails.root.join('spec/support/fixtures/valid_service.csv') }
 
   before(:all) do
     DatabaseCleaner.clean_with(:truncation)


### PR DESCRIPTION
In order to dynamically update the full-text search index when
entities change, the various models include callbacks to update their
parents via `touch`. This unnecessarily slows down the import because
touching in Rails 4 has a lot of overhead. Touching is not needed
during the import. Locations can be updated separately after the
import.

To bypass the touching, Rails provides a `no_touching` method, which
is what I've used here. It significantly sped up the import of a
medium-sized dataset from 31 minutes to 11 minutes.

The import script was also consuming more memory than necessary
because it was reading the CSV files with `File.read`, then loading
the contents in an array with `CVS.new.entries`.

The `File.read` part is not necessary since you can pass in a path
directly to `CSV.new` or `SmarterCSV.process`. SmarterCSV also provides
a way to load the contents in chunks to consume less memory.

Closes #361 