### PR TITLE
Replace Mandrill with SendGrid

### DIFF
--- a/app/controllers/api/v1/status_controller.rb
+++ b/app/controllers/api/v1/status_controller.rb
@@ -3,7 +3,7 @@ module Api
     class StatusController < ApplicationController
       def check_status
         response_hash = {}
-        response_hash[:dependencies] = %w(Mandrill Postgres)
+        response_hash[:dependencies] = %w(SendGrid Postgres)
         response_hash[:status] = everything_ok? ? 'ok' : 'NOT OK'
         response_hash[:updated] = Time.zone.now.to_i
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,11 +91,12 @@ Rails.application.configure do
 
   config.action_mailer.smtp_settings = {
     port:           '587',
-    address:        'smtp.mandrillapp.com',
-    user_name:      ENV['MANDRILL_USERNAME'],
-    password:       ENV['MANDRILL_APIKEY'],
+    address:        'smtp.sendgrid.net',
+    user_name:      ENV['SENDGRID_USERNAME'],
+    password:       ENV['SENDGRID_PASSWORD'],
     domain:         'heroku.com',
-    authentication: :plain
+    authentication: :plain,
+    enable_starttls_auto: true
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/script/setup_heroku
+++ b/script/setup_heroku
@@ -27,8 +27,8 @@ then
   echo "Installing Postgres"
   heroku addons:create heroku-postgresql --app $herokuApp
 
-  echo "Installing Mandrill by MailChimp"
-  heroku addons:create mandrill --app $herokuApp
+  echo "Installing SendGrid"
+  heroku addons:create sendgrid:starter --app $herokuApp
 
   echo "Installing Memcachier"
   heroku addons:create memcachier --app $herokuApp

--- a/spec/requests/status_spec.rb
+++ b/spec/requests/status_spec.rb
@@ -12,7 +12,7 @@ describe 'GET /api/.well-known/status' do
     end
 
     it 'lists all dependencies' do
-      expect(json['dependencies']).to eq(%w(Mandrill Postgres))
+      expect(json['dependencies']).to eq(%w(SendGrid Postgres))
     end
 
     it "returns 'ok' status" do
@@ -39,7 +39,7 @@ describe 'GET /api/.well-known/status' do
     end
 
     it 'lists all dependencies' do
-      expect(json['dependencies']).to eq(%w(Mandrill Postgres))
+      expect(json['dependencies']).to eq(%w(SendGrid Postgres))
     end
 
     it "returns 'updated' attribute set to current time as integer" do


### PR DESCRIPTION
**Why**:
Mandrill is getting rid of their free Heroku add-on. SendGrid still has a free plan as of today.

Closes #372