### PR TITLE
Update Devise to 4.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'kaminari'
 gem 'active_model_serializers', '~> 0.8.0'
 
 # Authentication
-gem 'devise', '~> 3.4'
+gem 'devise', '~> 4.1'
 
 # Authorization
 gem 'pundit'
@@ -80,6 +80,7 @@ group :test do
   gem 'coveralls', require: false
   gem 'rubocop'
   gem 'haml_lint'
+  gem 'test_after_commit'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,12 +106,11 @@ GEM
       rack (>= 1)
       rake (~> 10)
       thor (~> 0.19)
-    devise (3.5.10)
+    devise (4.1.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 3.2.6, < 5)
+      railties (>= 4.1.0, < 5.1)
       responders
-      thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
@@ -179,7 +178,7 @@ GEM
     memory_profiler (0.9.6)
     mime-types (2.99.1)
     mini_portile2 (2.1.0)
-    minitest (5.8.4)
+    minitest (5.9.0)
     multi_json (1.11.2)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -314,6 +313,8 @@ GEM
     sysexits (1.2.0)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
+    test_after_commit (1.1.0)
+      activerecord (>= 3.2)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
@@ -355,7 +356,7 @@ DEPENDENCIES
   dalli
   database_cleaner (>= 1.0.0.RC1)
   derailed
-  devise (~> 3.4)
+  devise (~> 4.1)
   enumerize
   factory_girl_rails (>= 4.2.0)
   figaro (~> 1.0)
@@ -393,6 +394,7 @@ DEPENDENCIES
   spring-watcher-listen
   stackprof
   sucker_punch
+  test_after_commit
   uglifier (>= 1.3.0)
   webmock
 

--- a/app/controllers/admin/registrations_controller.rb
+++ b/app/controllers/admin/registrations_controller.rb
@@ -7,8 +7,8 @@ class Admin
     protected
 
     def configure_permitted_parameters
-      devise_parameter_sanitizer.for(:sign_up).push(:name)
-      devise_parameter_sanitizer.for(:account_update).push(:name)
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:name])
     end
 
     def after_inactive_sign_up_path_for(_resource)

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -7,8 +7,8 @@ class User
     protected
 
     def configure_permitted_parameters
-      devise_parameter_sanitizer.for(:sign_up).push(:name)
-      devise_parameter_sanitizer.for(:account_update).push(:name)
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:name])
     end
 
     def after_update_path_for(_resource)

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -4,7 +4,7 @@ class Admin < ActiveRecord::Base
 
   # Devise already checks for presence of email and password.
   validates :name, presence: true
-  validates :email, uniqueness: { case_sensitive: false }
+  validates :email, email: true, uniqueness: { case_sensitive: false }
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ActiveRecord::Base
 
   # Devise checks for presence of email and password by default
   validates :name, presence: true
-  validates :email, uniqueness: { case_sensitive: false }
+  validates :email, email: true, uniqueness: { case_sensitive: false }
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable,


### PR DESCRIPTION
The `test_after_commit` gem is needed to test Devise confirmation
emails, which are now sent via the `after_commit` callback.
See this note in the Devise CHANGELOG:
https://github.com/plataformatec/devise/blob/master/CHANGELOG.md#410