### PR TITLE
Use QuotaGuard to avoid geocoder rate limits

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,5 +1,6 @@
 Geocoder.configure(
   lookup: :google,
+  http_proxy: ENV['QUOTAGUARD_URL'],
   always_raise: [
     Geocoder::OverQueryLimitError,
     Geocoder::RequestDenied,


### PR DESCRIPTION
When using Ohana's default settings for the `geocoder` gem in a Heroku deployment, it is really easy to hit Google's rate limit. This is due to the fact that there is a small pool of outbound IP addresses used by Heroku dynos and Google's rate limiting in the absence of an API key is IP address based.

This PR configures the `http_proxy` setting for the `geocoder` library to use the QuotaGuard service if `ENV['QUOTAGUARD_URL']` is present. If it is not present, this PR doesn't affect existing behavior. The use of the QuotaGuard Heroku addon with Rails is documented here: https://devcenter.heroku.com/articles/quotaguard#using-with-rails

Since Ohana's documentation for geocoder configuration lives in the wiki, I can update the wiki if this PR is accepted.