### PR TITLE
Expand the use of i18n

### DIFF
--- a/app/assets/javascripts/admin/accepted_payments.js
+++ b/app/assets/javascripts/admin/accepted_payments.js
@@ -1,5 +1,3 @@
 $(document).ready(function() {
-  $('#service_accepted_payments').select2({
-    placeholder: 'Select one or more payment methods'
-  });
+  $('#service_accepted_payments').select2();
 });

--- a/app/assets/javascripts/admin/funding_sources.js
+++ b/app/assets/javascripts/admin/funding_sources.js
@@ -1,5 +1,3 @@
 $(document).ready(function() {
-  $('#service_funding_sources,#organization_funding_sources').select2({
-    placeholder: 'Select one or more funding sources'
-  });
+  $('#service_funding_sources,#organization_funding_sources').select2();
 });

--- a/app/assets/javascripts/admin/languages.js
+++ b/app/assets/javascripts/admin/languages.js
@@ -1,5 +1,3 @@
 $(document).ready(function() {
-  $('#location_languages,#service_languages').select2({
-    placeholder: 'Select one or more languages'
-  });
+  $('#location_languages,#service_languages').select2();
 });

--- a/app/assets/javascripts/admin/required_documents.js
+++ b/app/assets/javascripts/admin/required_documents.js
@@ -1,5 +1,3 @@
 $(document).ready(function() {
-  $('#service_required_documents').select2({
-    placeholder: 'Select one or more required documents'
-  });
+  $('#service_required_documents').select2();
 });

--- a/app/assets/javascripts/admin/service_areas.js
+++ b/app/assets/javascripts/admin/service_areas.js
@@ -1,5 +1,3 @@
 $(document).ready(function() {
-  $('#service_service_areas').select2({
-    placeholder: 'Select one or more service areas'
-  });
+  $('#service_service_areas').select2();
 });

--- a/app/helpers/admin/form_helper.rb
+++ b/app/helpers/admin/form_helper.rb
@@ -93,7 +93,7 @@ class Admin
     def program_autocomplete_field_for(f)
       f.select(
         :program_id, @location.organization.programs.pluck(:name, :id),
-        { include_blank: 'This service is not part of any program' },
+        { include_blank: t('.include_blank') },
         class: 'form-control'
       )
     end

--- a/app/helpers/admin/form_helper.rb
+++ b/app/helpers/admin/form_helper.rb
@@ -78,7 +78,7 @@ class Admin
           id: 'org-name',
           class: 'form-control',
           data: { 'ajax-url' => admin_organizations_url,
-                  'placeholder' => 'Choose an organization' }
+                  'placeholder' => t('.placeholder') }
         )
       else
         f.select(

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -12,9 +12,9 @@ class Address < ActiveRecord::Base
 
   validates :state_province, state_province: true
 
-  validates :country, length: { maximum: 2, minimum: 2 }
+  validates :country, length: { allow_blank: true, maximum: 2, minimum: 2 }
 
-  validates :postal_code, zip: true
+  validates :postal_code, zip: { allow_blank: true }
 
   auto_strip_attributes :address_1, :address_2, :city, :state_province, :postal_code,
                         :country, squish: true

--- a/app/models/holiday_schedule.rb
+++ b/app/models/holiday_schedule.rb
@@ -12,5 +12,5 @@ class HolidaySchedule < ActiveRecord::Base
 
   validates :opens_at, :closes_at,
             presence: { message: I18n.t('errors.messages.blank_for_hs_open') },
-            unless: ->(hs) { hs.closed? }
+            unless: :closed?
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -31,10 +31,8 @@ class Location < ActiveRecord::Base
                                 allow_destroy: true, reject_if: :all_blank
 
   validates :address,
-            presence: {
-              message: I18n.t('errors.messages.no_address')
-            },
-            unless: ->(location) { location.virtual? }
+            presence: { message: I18n.t('errors.messages.no_address') },
+            unless: :virtual?
 
   validates :description, :organization, :name,
             presence: { message: I18n.t('errors.messages.blank_for_location') }

--- a/app/models/mail_address.rb
+++ b/app/models/mail_address.rb
@@ -13,9 +13,9 @@ class MailAddress < ActiveRecord::Base
 
   validates :state_province, state_province: true
 
-  validates :country, length: { maximum: 2, minimum: 2 }
+  validates :country, length: { allow_blank: true, maximum: 2, minimum: 2 }
 
-  validates :postal_code, zip: true
+  validates :postal_code, zip: { allow_blank: true }
 
   auto_strip_attributes :attention, :address_1, :address_2, :city, :state_province,
                         :postal_code, :country, squish: true

--- a/app/models/phone.rb
+++ b/app/models/phone.rb
@@ -13,7 +13,7 @@ class Phone < ActiveRecord::Base
 
   validates :number,
             presence: { message: I18n.t('errors.messages.blank_for_phone') },
-            phone: { unless: ->(phone) { phone.number == '711' } }
+            phone: { allow_blank: true, unless: ->(phone) { phone.number == '711' } }
 
   validates :number_type,
             presence: { message: I18n.t('errors.messages.blank_for_phone') }

--- a/app/models/regular_schedule.rb
+++ b/app/models/regular_schedule.rb
@@ -11,5 +11,5 @@ class RegularSchedule < ActiveRecord::Base
   validates :weekday, :opens_at, :closes_at,
             presence: { message: I18n.t('errors.messages.blank_for_rs') }
 
-  validates :weekday, weekday: true
+  validates :weekday, weekday: { allow_blank: true }
 end

--- a/app/views/admin/contacts/forms/_department.html.haml
+++ b/app/views/admin/contacts/forms/_department.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :department, 'Contact Department'
+    = f.label :department
   = field_set_tag do
     .row
       .col-sm-6

--- a/app/views/admin/contacts/forms/_email.html.haml
+++ b/app/views/admin/contacts/forms/_email.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :email, 'Contact Email'
+    = f.label :email
   = field_set_tag do
     .row
       .col-sm-6

--- a/app/views/admin/contacts/forms/_title.html.haml
+++ b/app/views/admin/contacts/forms/_title.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :title, 'Contact Title'
+    = f.label :title
   = field_set_tag do
     .row
       .col-sm-6

--- a/app/views/admin/locations/forms/_accessibility.html.haml
+++ b/app/views/admin/locations/forms/_accessibility.html.haml
@@ -3,7 +3,8 @@
     %strong
       Accessibility Options
     %p.desc
-      Which accessibility amenities are available at this location?
+      = t('.description')
+
   = field_set_tag nil, class: 'accessibility' do
     = f.collection_check_boxes(:accessibility, Location.accessibility.options, :last, :first) do |b|
       .checkbox

--- a/app/views/admin/locations/forms/_accessibility.html.haml
+++ b/app/views/admin/locations/forms/_accessibility.html.haml
@@ -1,7 +1,7 @@
 .inst-box
   %header
     %strong
-      Accessibility Options
+      = f.label :accessibility
     %p.desc
       = t('.description')
 

--- a/app/views/admin/locations/forms/_address.html.haml
+++ b/app/views/admin/locations/forms/_address.html.haml
@@ -1,7 +1,7 @@
 .inst-box.address
   %header
     %strong
-      Street Address
+      = f.label :address
     %span.desc
       = t('.description')
 

--- a/app/views/admin/locations/forms/_address.html.haml
+++ b/app/views/admin/locations/forms/_address.html.haml
@@ -3,7 +3,8 @@
     %strong
       Street Address
     %span.desc
-      The physical location.
+      = t('.description')
+
   = f.fields_for :address do |builder|
     = render 'admin/locations/forms/address_fields', f: builder
   - unless @location.address.present?

--- a/app/views/admin/locations/forms/_address_fields.html.haml
+++ b/app/views/admin/locations/forms/_address_fields.html.haml
@@ -1,31 +1,31 @@
 = field_set_tag do
   .form-group
-    = f.label :address_1, 'Street (Line 1)'
+    = f.label :address_1
     .row
       .col-sm-6
         = f.text_field :address_1, class: 'form-control'
   .form-group
-    = f.label :address_2, 'Street (Line 2)'
+    = f.label :address_2
     .row
       .col-sm-6
         = f.text_field :address_2, class: 'form-control'
   .form-group
-    = f.label :city, 'City'
+    = f.label :city
     .row
       .col-sm-6
         = f.text_field :city, maxlength: 255, class: 'form-control'
   .form-group
-    = f.label :state_province, 'State (2-letter abbreviation)'
+    = f.label :state_province
     .row
       .col-sm-2
         = f.text_field :state_province, maxlength: 2, class: 'form-control'
   .form-group
-    = f.label :postal_code, 'ZIP Code'
+    = f.label :postal_code
     .row
       .col-xs-4
         = f.text_field :postal_code, maxlength: 5, class: 'form-control'
   .form-group
-    = f.label :country, 'ISO 3361-1 2-letter Country Code'
+    = f.label :country
     .row
       .col-sm-2
         = f.text_field :country, maxlength: 2, class: 'form-control'

--- a/app/views/admin/locations/forms/_admin_emails.html.haml
+++ b/app/views/admin/locations/forms/_admin_emails.html.haml
@@ -3,7 +3,7 @@
     %strong
       Add an admin to this location
     %p.desc
-      Which email addresses should be allowed to update and delete this location?
+      = t('.description')
 
   - if f.object.new_record? && !current_admin.super_admin?
     = render 'admin/locations/forms/admin_email_fields_for_new_location'

--- a/app/views/admin/locations/forms/_admin_emails.html.haml
+++ b/app/views/admin/locations/forms/_admin_emails.html.haml
@@ -1,7 +1,7 @@
 .inst-box.admin_emails
   %header
     %strong
-      Add an admin to this location
+      = f.label :admin_emails
     %p.desc
       = t('.description')
 

--- a/app/views/admin/locations/forms/_description.html.haml
+++ b/app/views/admin/locations/forms/_description.html.haml
@@ -2,6 +2,7 @@
   %header
     = f.label :description, 'Description'
     %span.desc
-      A description of the location's services.
+      = t('.description')
+
   = field_set_tag do
     = f.text_area :description, required: false, class: 'form-control', rows: 10

--- a/app/views/admin/locations/forms/_description.html.haml
+++ b/app/views/admin/locations/forms/_description.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :description, 'Description'
+    = f.label :description
     %span.desc
       = t('.description')
 

--- a/app/views/admin/locations/forms/_holiday_schedule_fields.html.haml
+++ b/app/views/admin/locations/forms/_holiday_schedule_fields.html.haml
@@ -1,26 +1,26 @@
 = field_set_tag do
   .form-group
-    = f.label :start_date, 'Start date'
+    = f.label :start_date
     .row
       .col-md-6
         = f.date_select :start_date, include_blank: true, discard_year: true, class: 'form-control'
   .form-group
-    = f.label :end_date, 'End date'
+    = f.label :end_date
     .row
       .col-md-6
         = f.date_select :end_date, include_blank: true, discard_year: true, class: 'form-control'
   .form-group
-    = f.label :closed, 'Closed or open during the above dates?'
+    = f.label :closed
     .row
       .col-md-6
         = f.select :closed, [['Closed', true], ['Open', false]]
   .form-group
-    = f.label :opens_at, 'If open, enter the opening and closing hours below:'
+    %b= t('.enter_hours')
     .row
       .col-md-6
-        Opens at:
+        = f.label :opens_at
         = f.time_select :opens_at, minute_step: 15, prompt: true, ampm: true, ignore_date: true
-        Closes at:
+        = f.label :closes_at
         = f.time_select :closes_at, minute_step: 15, prompt: true, ampm: true, ignore_date: true
 
   = f.hidden_field :_destroy

--- a/app/views/admin/locations/forms/_languages.html.haml
+++ b/app/views/admin/locations/forms/_languages.html.haml
@@ -2,5 +2,6 @@
   %header
     %strong
       Languages spoken at the location
+
   = field_set_tag do
-    = f.select :languages, SETTINGS.try(:[], :languages), {}, multiple: true, class: 'form-control'
+    = f.select :languages, SETTINGS.try(:[], :languages), {}, multiple: true, class: 'form-control', data: { placeholder: t('.placeholder') }

--- a/app/views/admin/locations/forms/_mail_address_fields.html.haml
+++ b/app/views/admin/locations/forms/_mail_address_fields.html.haml
@@ -1,36 +1,36 @@
 = field_set_tag do
   .form-group
-    = f.label :attention, 'Attention'
+    = f.label :attention
     .row
       .col-sm-6
         = f.text_field :attention, maxlength: 255, class: 'form-control'
   .form-group
-    = f.label :address_1, 'Street (Line 1)'
+    = f.label :address_1
     .row
       .col-sm-6
         = f.text_field :address_1, class: 'form-control'
   .form-group
-    = f.label :address_2, 'Street (Line 2)'
+    = f.label :address_2
     .row
       .col-sm-6
         = f.text_field :address_2, class: 'form-control'
   .form-group
-    = f.label :city, 'City'
+    = f.label :city
     .row
       .col-sm-6
         = f.text_field :city, maxlength: 255, class: 'form-control'
   .form-group
-    = f.label :state_province, 'State (2-letter abbreviation)'
+    = f.label :state_province
     .row
       .col-sm-2
         = f.text_field :state_province, maxlength: 2, class: 'form-control'
   .form-group
-    = f.label :postal_code, 'ZIP Code'
+    = f.label :postal_code
     .row
       .col-xs-4
         = f.text_field :postal_code, maxlength: 10, class: 'form-control'
   .form-group
-    = f.label :country, 'ISO 3361-1 2-letter Country Code'
+    = f.label :country
     .row
       .col-sm-2
         = f.text_field :country, maxlength: 2, class: 'form-control'

--- a/app/views/admin/locations/forms/_phone_fields.html.haml
+++ b/app/views/admin/locations/forms/_phone_fields.html.haml
@@ -14,7 +14,7 @@
     .row
       .col-md-4
         - if f.object.new_record?
-          = f.select :number_type, Phone.number_type.options, { prompt: 'Choose an option' }, class: 'form-control'
+          = f.select :number_type, Phone.number_type.options, { prompt: t('.number_type.prompt') }, class: 'form-control'
         - else
           = f.select :number_type, Phone.number_type.options, {}, class: 'form-control'
   .form-group

--- a/app/views/admin/locations/forms/_phone_fields.html.haml
+++ b/app/views/admin/locations/forms/_phone_fields.html.haml
@@ -1,16 +1,16 @@
 = field_set_tag do
   .form-group
-    = f.label :number, 'Number'
+    = f.label :number
     .row
       .col-md-4
         = f.telephone_field :number, maxlength: 14, class: 'form-control'
   .form-group
-    = f.label :vanity_number, 'Vanity Number (for example: 650-123-HELP)'
+    = f.label :vanity_number
     .row
       .col-md-4
         = f.telephone_field :vanity_number, maxlength: 14, class: 'form-control'
   .form-group
-    = f.label :number_type, 'Number Type (Fax, Hotline, Voice, SMS, or TTY)'
+    = f.label :number_type
     .row
       .col-md-4
         - if f.object.new_record?
@@ -18,17 +18,17 @@
         - else
           = f.select :number_type, Phone.number_type.options, {}, class: 'form-control'
   .form-group
-    = f.label :extension, 'Extension (numbers only)'
+    = f.label :extension
     .row
       .col-md-4
         = f.text_field :extension, maxlength: 8, class: 'form-control'
   .form-group
-    = f.label :department, 'Department'
+    = f.label :department
     .row
       .col-md-4
         = f.text_field :department, maxlength: 50, class: 'form-control'
   .form-group
-    = f.label :country_prefix, 'Country Prefix Code (for example: 1)'
+    = f.label :country_prefix
     .row
       .col-md-4
         = f.telephone_field :country_prefix, maxlength: 4, class: 'form-control'

--- a/app/views/admin/locations/forms/_phones.html.haml
+++ b/app/views/admin/locations/forms/_phones.html.haml
@@ -5,7 +5,8 @@
     - unless f.object.class == Contact
       %p.desc
         %em
-          If the phone number belongs to a contact, please move it to the existing contact, or add a new contact.
+          = t('.description')
+
   = f.fields_for :phones do |builder|
     = render 'admin/locations/forms/phone_fields', f: builder
   = link_to_add_fields t('admin.buttons.add_phone'), f, :phones

--- a/app/views/admin/locations/forms/_regular_schedule_fields.html.haml
+++ b/app/views/admin/locations/forms/_regular_schedule_fields.html.haml
@@ -1,5 +1,5 @@
 = field_set_tag do
-  = f.select :weekday, weekday_select_field, include_blank: 'Day'
+  = f.select :weekday, weekday_select_field, include_blank: t('.weekday.include_blank')
   Opens at:
   = f.time_select :opens_at, minute_step: 15, prompt: true, ampm: true
   Closes at:

--- a/app/views/admin/locations/forms/_short_desc.html.haml
+++ b/app/views/admin/locations/forms/_short_desc.html.haml
@@ -2,6 +2,7 @@
   %header
     = f.label :short_desc, 'Short Description'
     %span.desc
-      A short summary of the description of services.
+      = t('.description')
+
   = field_set_tag do
     = f.text_area :short_desc, class: 'form-control'

--- a/app/views/admin/locations/forms/_short_desc.html.haml
+++ b/app/views/admin/locations/forms/_short_desc.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :short_desc, 'Short Description'
+    = f.label :short_desc
     %span.desc
       = t('.description')
 

--- a/app/views/admin/locations/forms/_transportation.html.haml
+++ b/app/views/admin/locations/forms/_transportation.html.haml
@@ -2,6 +2,7 @@
   %header
     = f.label :transportation, 'Transportation Options'
     %span.desc
-      What public transportation options are nearby? (Bus stops, train stations, etc.)
+      = t('.description')
+
   %p
     = f.text_area :transportation, class: 'form-control', maxlength: 255

--- a/app/views/admin/locations/forms/_transportation.html.haml
+++ b/app/views/admin/locations/forms/_transportation.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :transportation, 'Transportation Options'
+    = f.label :transportation
     %span.desc
       = t('.description')
 

--- a/app/views/admin/locations/forms/_virtual.html.haml
+++ b/app/views/admin/locations/forms/_virtual.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :virtual, 'Type of location'
+    = f.label :virtual
     %span.desc
       = t('.description')
 

--- a/app/views/admin/locations/forms/_virtual.html.haml
+++ b/app/views/admin/locations/forms/_virtual.html.haml
@@ -2,7 +2,8 @@
   %header
     = f.label :virtual, 'Type of location'
     %span.desc
-      Does this location have a physical address?
+      = t('.description')
+
   = field_set_tag do
     .row
       .col-md-4

--- a/app/views/admin/organizations/forms/_accreditations.html.haml
+++ b/app/views/admin/organizations/forms/_accreditations.html.haml
@@ -1,7 +1,7 @@
 .inst-box
   %header
     %strong
-      Accreditations
+      = f.label :accreditations
     %p.desc
       = t('.description')
 

--- a/app/views/admin/organizations/forms/_accreditations.html.haml
+++ b/app/views/admin/organizations/forms/_accreditations.html.haml
@@ -3,7 +3,7 @@
     %strong
       Accreditations
     %p.desc
-      You can enter multiple terms in this box by pressing the comma key after each one.
+      = t('.description')
 
   = field_set_tag do
     = text_field_tag 'organization[accreditations][]', @organization.accreditations.join(','), id: 'organization_accreditations', class: 'form-control'

--- a/app/views/admin/organizations/forms/_date_incorporated.html.haml
+++ b/app/views/admin/organizations/forms/_date_incorporated.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :date_incorporated, 'Date of Incorporation'
+    = f.label :date_incorporated
     %span.desc
       = t('.description')
 

--- a/app/views/admin/organizations/forms/_date_incorporated.html.haml
+++ b/app/views/admin/organizations/forms/_date_incorporated.html.haml
@@ -2,7 +2,8 @@
   %header
     = f.label :date_incorporated, 'Date of Incorporation'
     %span.desc
-      The date the organization was incorporated.
+      = t('.description')
+
   = field_set_tag do
     .row
       .col-sm-6

--- a/app/views/admin/organizations/forms/_description.html.haml
+++ b/app/views/admin/organizations/forms/_description.html.haml
@@ -2,6 +2,7 @@
   %header
     = f.label :description, 'Description'
     %span.desc
-      A description of what the organization does.
+      = t('.description')
+
   = field_set_tag do
     = f.text_area :description, required: false, class: 'form-control', rows: 10

--- a/app/views/admin/organizations/forms/_description.html.haml
+++ b/app/views/admin/organizations/forms/_description.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :description, 'Description'
+    = f.label :description
     %span.desc
       = t('.description')
 

--- a/app/views/admin/organizations/forms/_legal_status.html.haml
+++ b/app/views/admin/organizations/forms/_legal_status.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :legal_status, 'Legal Status'
+    = f.label :legal_status
     %span.desc
       = t('.description')
 

--- a/app/views/admin/organizations/forms/_legal_status.html.haml
+++ b/app/views/admin/organizations/forms/_legal_status.html.haml
@@ -2,7 +2,8 @@
   %header
     = f.label :legal_status, 'Legal Status'
     %span.desc
-      The conditions this organization is operating under (e.g. non-profit, private corporation or a government organization).
+      = t('.description')
+
   = field_set_tag do
     .row
       .col-sm-6

--- a/app/views/admin/organizations/forms/_licenses.html.haml
+++ b/app/views/admin/organizations/forms/_licenses.html.haml
@@ -3,7 +3,7 @@
     %strong
       Licenses
     %p.desc
-      You can enter multiple terms in this box by pressing the comma key after each one.
+      = t('.description')
 
   = field_set_tag do
     = text_field_tag 'organization[licenses][]', @organization.licenses.join(','), id: 'organization_licenses', class: 'form-control'

--- a/app/views/admin/organizations/forms/_licenses.html.haml
+++ b/app/views/admin/organizations/forms/_licenses.html.haml
@@ -1,7 +1,7 @@
 .inst-box
   %header
     %strong
-      Licenses
+      = f.label :licenses
     %p.desc
       = t('.description')
 

--- a/app/views/admin/organizations/forms/_tax_id.html.haml
+++ b/app/views/admin/organizations/forms/_tax_id.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :tax_id, 'Tax Identifier'
+    = f.label :tax_id
     %span.desc
       = t('.description')
 

--- a/app/views/admin/organizations/forms/_tax_id.html.haml
+++ b/app/views/admin/organizations/forms/_tax_id.html.haml
@@ -2,7 +2,8 @@
   %header
     = f.label :tax_id, 'Tax Identifier'
     %span.desc
-      Tax identifier such as the Federal Employer Identification Number.
+      = t('.description')
+
   = field_set_tag do
     .row
       .col-sm-6

--- a/app/views/admin/organizations/forms/_tax_status.html.haml
+++ b/app/views/admin/organizations/forms/_tax_status.html.haml
@@ -2,7 +2,8 @@
   %header
     = f.label :tax_status, 'Tax Status'
     %span.desc
-      Internal Revenue Service tax designation, such as 501(c)(3).
+      = t('.description')
+
   = field_set_tag do
     .row
       .col-sm-6

--- a/app/views/admin/organizations/forms/_tax_status.html.haml
+++ b/app/views/admin/organizations/forms/_tax_status.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :tax_status, 'Tax Status'
+    = f.label :tax_status
     %span.desc
       = t('.description')
 

--- a/app/views/admin/services/forms/_accepted_payments.html.haml
+++ b/app/views/admin/services/forms/_accepted_payments.html.haml
@@ -2,5 +2,6 @@
   %header
     %strong
       Accepted Payments
+
   = field_set_tag do
-    = f.select :accepted_payments, SETTINGS.try(:[], :accepted_payments), {}, multiple: true, class: 'form-control'
+    = f.select :accepted_payments, SETTINGS.try(:[], :accepted_payments), {}, multiple: true, class: 'form-control', data: { placeholder: t('.placeholder') }

--- a/app/views/admin/services/forms/_application_process.haml
+++ b/app/views/admin/services/forms/_application_process.haml
@@ -2,6 +2,7 @@
   %header
     = f.label :application_process, 'Application process'
     %p.desc
-      How does a client apply to receive services, if applicable?
+      = t('.description')
+
   %p
     = f.text_area :application_process, class: 'form-control'

--- a/app/views/admin/services/forms/_application_process.haml
+++ b/app/views/admin/services/forms/_application_process.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :application_process, 'Application process'
+    = f.label :application_process
     %p.desc
       = t('.description')
 

--- a/app/views/admin/services/forms/_audience.html.haml
+++ b/app/views/admin/services/forms/_audience.html.haml
@@ -2,6 +2,7 @@
   %header
     = f.label :audience, 'Audience'
     %p.desc
-      What groups are served, if not everyone?
+      = t('.description')
+
   %p
     = f.text_area :audience, class: 'form-control'

--- a/app/views/admin/services/forms/_audience.html.haml
+++ b/app/views/admin/services/forms/_audience.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :audience, 'Audience'
+    = f.label :audience
     %p.desc
       = t('.description')
 

--- a/app/views/admin/services/forms/_categories.html.haml
+++ b/app/views/admin/services/forms/_categories.html.haml
@@ -1,7 +1,7 @@
 .inst-box
   %header
     %strong
-      Categories
+      = f.label :categories
     %p.desc
       = t('.description')
 

--- a/app/views/admin/services/forms/_categories.html.haml
+++ b/app/views/admin/services/forms/_categories.html.haml
@@ -3,7 +3,8 @@
     %strong
       Categories
     %p.desc
-      What categories best describe this service?
+      = t('.description')
+
   = hidden_field_tag 'service[category_ids][]', nil
   = field_set_tag nil, id: 'categories' do
     = nested_categories(Category.arrange(order: :taxonomy_id))

--- a/app/views/admin/services/forms/_description.html.haml
+++ b/app/views/admin/services/forms/_description.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :description, 'Description'
+    = f.label :description
     %span.desc
       = t('.description')
 

--- a/app/views/admin/services/forms/_description.html.haml
+++ b/app/views/admin/services/forms/_description.html.haml
@@ -2,6 +2,7 @@
   %header
     = f.label :description, 'Description'
     %span.desc
-      A description of the service.
+      = t('.description')
+
   = field_set_tag do
     = f.text_area :description, required: false, class: 'form-control', rows: 5

--- a/app/views/admin/services/forms/_eligibility.html.haml
+++ b/app/views/admin/services/forms/_eligibility.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :eligibility, 'Eligibility'
+    = f.label :eligibility
     %p.desc
       = t('.description')
 

--- a/app/views/admin/services/forms/_eligibility.html.haml
+++ b/app/views/admin/services/forms/_eligibility.html.haml
@@ -2,6 +2,7 @@
   %header
     = f.label :eligibility, 'Eligibility'
     %p.desc
-      What criteria must served groups meet to receive service?
+      = t('.description')
+
   %p
     = f.text_area :eligibility, class: 'form-control'

--- a/app/views/admin/services/forms/_fees.html.haml
+++ b/app/views/admin/services/forms/_fees.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :fees, 'Fees'
+    = f.label :fees
     %p.desc
       = t('.description')
 

--- a/app/views/admin/services/forms/_fees.html.haml
+++ b/app/views/admin/services/forms/_fees.html.haml
@@ -2,6 +2,7 @@
   %header
     = f.label :fees, 'Fees'
     %p.desc
-      Are there any fees to receive this service?
+      = t('.description')
+
   %p
     = f.text_area :fees, class: 'form-control'

--- a/app/views/admin/services/forms/_interpretation_services.html.haml
+++ b/app/views/admin/services/forms/_interpretation_services.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :interpretation_services, 'Interpretation Services'
+    = f.label :interpretation_services
     %p.desc
       = t('.description')
 

--- a/app/views/admin/services/forms/_interpretation_services.html.haml
+++ b/app/views/admin/services/forms/_interpretation_services.html.haml
@@ -2,6 +2,7 @@
   %header
     = f.label :interpretation_services, 'Interpretation Services'
     %p.desc
-      What kind of interpretation services are available?
+      = t('.description')
+
   %p
     = f.text_area :interpretation_services, class: 'form-control'

--- a/app/views/admin/services/forms/_keywords.html.haml
+++ b/app/views/admin/services/forms/_keywords.html.haml
@@ -1,7 +1,7 @@
 .inst-box
   %header
     %strong
-      Keywords
+      = f.label :keywords
     %p.desc
       = t('.description')
 

--- a/app/views/admin/services/forms/_keywords.html.haml
+++ b/app/views/admin/services/forms/_keywords.html.haml
@@ -3,11 +3,7 @@
     %strong
       Keywords
     %p.desc
-      The best way to ensure a service appears in search results is to write
-      a detailed and accurate service description. If certain words or phrases
-      cannot be part of the description, such as common misspellings, then the
-      keywords field is where you can add them. You can enter multiple
-      keywords in this box by pressing the comma key after each one.
+      = t('.description')
 
   = field_set_tag do
     = text_field_tag 'service[keywords][]', @service.keywords.join(','), id: 'service_keywords', class: 'form-control'

--- a/app/views/admin/services/forms/_languages.html.haml
+++ b/app/views/admin/services/forms/_languages.html.haml
@@ -2,5 +2,6 @@
   %header
     %strong
       Languages this service is provided in.
+
   = field_set_tag do
-    = f.select :languages, SETTINGS.try(:[], :languages), {}, multiple: true, class: 'form-control'
+    = f.select :languages, SETTINGS.try(:[], :languages), {}, multiple: true, class: 'form-control', data: { placeholder: t('.placeholder') }

--- a/app/views/admin/services/forms/_program.html.haml
+++ b/app/views/admin/services/forms/_program.html.haml
@@ -1,6 +1,6 @@
 .inst-box.program
   %header
-    = f.label :program_id, 'Service Program'
+    = f.label :program_id
     %span.desc
       = t('.description')
 

--- a/app/views/admin/services/forms/_program.html.haml
+++ b/app/views/admin/services/forms/_program.html.haml
@@ -2,6 +2,7 @@
   %header
     = f.label :program_id, 'Service Program'
     %span.desc
-      If this service is associated with a program, enter it below.
+      = t('.description')
+
   %p
     = program_autocomplete_field_for(f)

--- a/app/views/admin/services/forms/_required_documents.html.haml
+++ b/app/views/admin/services/forms/_required_documents.html.haml
@@ -2,5 +2,6 @@
   %header
     %strong
       The documents required to receive this service.
+
   = field_set_tag do
-    = f.select :required_documents, SETTINGS.try(:[], :required_documents), {}, multiple: true, class: 'form-control'
+    = f.select :required_documents, SETTINGS.try(:[], :required_documents), {}, multiple: true, class: 'form-control', data: { placeholder: t('.placeholder') }

--- a/app/views/admin/services/forms/_service_areas.html.haml
+++ b/app/views/admin/services/forms/_service_areas.html.haml
@@ -1,7 +1,7 @@
 .inst-box
   %header
     %strong
-      Service Areas
+      = f.label :service_areas
     %p.desc
       = t('.description')
 

--- a/app/views/admin/services/forms/_service_areas.html.haml
+++ b/app/views/admin/services/forms/_service_areas.html.haml
@@ -3,7 +3,7 @@
     %strong
       Service Areas
     %p.desc
-      What city or county does the location serve?
+      = t('.description')
 
   = field_set_tag do
     = f.select :service_areas, SETTINGS.try(:[], :valid_service_areas), {}, multiple: true, class: 'form-control', data: { placeholder: t('.placeholder') }

--- a/app/views/admin/services/forms/_service_areas.html.haml
+++ b/app/views/admin/services/forms/_service_areas.html.haml
@@ -6,4 +6,4 @@
       What city or county does the location serve?
 
   = field_set_tag do
-    = f.select :service_areas, SETTINGS.try(:[], :valid_service_areas), {}, multiple: true, class: 'form-control'
+    = f.select :service_areas, SETTINGS.try(:[], :valid_service_areas), {}, multiple: true, class: 'form-control', data: { placeholder: t('.placeholder') }

--- a/app/views/admin/services/forms/_status.html.haml
+++ b/app/views/admin/services/forms/_status.html.haml
@@ -1,7 +1,7 @@
 .inst-box
   %header
     %strong
-      Status
+      = f.label :status
     %p.desc
       = t('.description')
 

--- a/app/views/admin/services/forms/_status.html.haml
+++ b/app/views/admin/services/forms/_status.html.haml
@@ -3,7 +3,7 @@
     %strong
       Status
     %p.desc
-      Is this service active, inactive, or defunct?
+      = t('.description')
 
   = field_set_tag do
     - if f.object.new_record?

--- a/app/views/admin/services/forms/_wait.html.haml
+++ b/app/views/admin/services/forms/_wait.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :wait_time, 'Wait Time'
+    = f.label :wait_time
     %p.desc
       = t('.description')
 

--- a/app/views/admin/services/forms/_wait.html.haml
+++ b/app/views/admin/services/forms/_wait.html.haml
@@ -2,6 +2,7 @@
   %header
     = f.label :wait_time, 'Wait Time'
     %p.desc
-      How long on average does a client need to wait to receive services?
+      = t('.description')
+
   %p
     = f.text_area :wait_time, class: 'form-control'

--- a/app/views/admin/shared/forms/_alternate_name.html.haml
+++ b/app/views/admin/shared/forms/_alternate_name.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :alternate_name, 'Alternate Name'
+    = f.label :alternate_name
     %span.desc
       = t('.description', type: f.object.model_name.human.downcase)
 

--- a/app/views/admin/shared/forms/_alternate_name.html.haml
+++ b/app/views/admin/shared/forms/_alternate_name.html.haml
@@ -2,7 +2,8 @@
   %header
     = f.label :alternate_name, 'Alternate Name'
     %span.desc
-      Is this #{f.object.class.to_s.downcase} known by another name?
+      = t('.description', type: f.object.model_name.human.downcase)
+
   = field_set_tag do
     .row
       .col-sm-6

--- a/app/views/admin/shared/forms/_choose_org.html.haml
+++ b/app/views/admin/shared/forms/_choose_org.html.haml
@@ -1,6 +1,6 @@
 - if f.object.new_record?
   .inst-box
     %header
-      = f.label :organization_id, 'Choose an organization to create this program for.'
+      = f.label :organization_id
     %p
       = org_autocomplete_field_for(f, current_admin)

--- a/app/views/admin/shared/forms/_email.html.haml
+++ b/app/views/admin/shared/forms/_email.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :email, 'Email'
+    = f.label :email
     %span.desc
       = t('.description', type: f.object.model_name.human.downcase)
 

--- a/app/views/admin/shared/forms/_email.html.haml
+++ b/app/views/admin/shared/forms/_email.html.haml
@@ -2,7 +2,8 @@
   %header
     = f.label :email, 'Email'
     %span.desc
-      The #{f.object.class.to_s.downcase}'s general email.
+      = t('.description', type: f.object.model_name.human.downcase)
+
   = field_set_tag do
     .row
       .col-sm-6

--- a/app/views/admin/shared/forms/_funding_sources.html.haml
+++ b/app/views/admin/shared/forms/_funding_sources.html.haml
@@ -4,5 +4,6 @@
       Funding Sources
     %p.desc
       How is this #{f.object.class.to_s.downcase} funded?
+
   = field_set_tag do
-    = f.select :funding_sources, SETTINGS.try(:[], :funding_sources), {}, multiple: true, class: 'form-control'
+    = f.select :funding_sources, SETTINGS.try(:[], :funding_sources), {}, multiple: true, class: 'form-control', data: { placeholder: t('.placeholder') }

--- a/app/views/admin/shared/forms/_funding_sources.html.haml
+++ b/app/views/admin/shared/forms/_funding_sources.html.haml
@@ -3,7 +3,7 @@
     %strong
       Funding Sources
     %p.desc
-      How is this #{f.object.class.to_s.downcase} funded?
+      = t('.description', type: f.object.model_name.human.downcase)
 
   = field_set_tag do
     = f.select :funding_sources, SETTINGS.try(:[], :funding_sources), {}, multiple: true, class: 'form-control', data: { placeholder: t('.placeholder') }

--- a/app/views/admin/shared/forms/_funding_sources.html.haml
+++ b/app/views/admin/shared/forms/_funding_sources.html.haml
@@ -1,7 +1,7 @@
 .inst-box.funding_sources
   %header
     %strong
-      Funding Sources
+      = f.label :funding_sources
     %p.desc
       = t('.description', type: f.object.model_name.human.downcase)
 

--- a/app/views/admin/shared/forms/_name.html.haml
+++ b/app/views/admin/shared/forms/_name.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :name, "#{f.object.class} Name"
+    = f.label :name
   = field_set_tag do
     .row
       .col-sm-6

--- a/app/views/admin/shared/forms/_website.html.haml
+++ b/app/views/admin/shared/forms/_website.html.haml
@@ -1,6 +1,6 @@
 .inst-box
   %header
-    = f.label :website, "#{f.object.class} Website"
+    = f.label :website
   = field_set_tag do
     .row
       .col-sm-6

--- a/app/views/api_applications/_form.html.haml
+++ b/app/views/api_applications/_form.html.haml
@@ -6,13 +6,13 @@
         - @api_application.errors.full_messages.each do |msg|
           %li= msg
   .form-group
-    = f.label :name, 'Application Name'
+    = f.label :name
     = f.text_field :name, class: 'form-control'
   .form-group
-    = f.label :main_url, 'Main URL'
+    = f.label :main_url
     = f.text_field :main_url, class: 'form-control'
   .form-group
-    = f.label :callback_url, 'Callback URL'
+    = f.label :callback_url
     = f.text_field :callback_url, class: 'form-control'
   - if f.object.new_record?
     .actions

--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -4,10 +4,10 @@
     = devise_error_messages!
     = f.hidden_field :reset_password_token
     .form-group
-      = f.label :password, 'New password'
+      = f.label :password
       = f.password_field :password, autofocus: true, autocomplete: 'off', class: 'form-control'
     .form-group
-      = f.label :password_confirmation, 'Confirm new password'
+      = f.label :password_confirmation
       = f.password_field :password_confirmation, autocomplete: 'off', class: 'form-control'
     = f.submit t('buttons.change_my_password'), class: 'button right'
     %br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,11 +22,97 @@
 en:
   activerecord:
     attributes:
-      address:
+      address: &address_attributes
+        address_1: 'Street (Line 1)'
+        address_2: 'Street (Line 2)'
+        city: 'City'
+        country: 'Country Code'
+        postal_code: 'ZIP Code'
         state_province: 'State'
 
+      api_application:
+        name: 'Application Name'
+        main_url: 'Main URL'
+        callback_url: 'Callback URL'
+
+      contact:
+        email: 'Contact Email'
+        department: 'Contact Department'
+        phones: 'Phone Numbers'
+        title: 'Contact Title'
+
+      contact/phones:
+        number: :activerecord.attributes.phone.number
+        number_type: :activerecord.attributes.phone.number_type
+
+      holiday_schedule: &holiday_schedule_attributes
+        closed: 'Open/Closed'
+        closes_at: 'Closes At'
+        opens_at: 'Opens At'
+        end_date: 'End Date'
+        start_date: 'Start Date'
+
+      location:
+        accessibility: 'Accessibility Options'
+        address: 'Street Address'
+        admin_emails: 'Admin Emails'
+        alternate_name: 'Alternate Name'
+        phones: 'Phone Numbers'
+        transportation: 'Transportation Options'
+        short_desc: 'Short Description'
+        virtual: 'Type of Location'
+        website: 'Location Website'
+
+      location/holiday_schedules:
+        <<: *holiday_schedule_attributes
+
+      location/phones:
+        number: :activerecord.attributes.phone.number
+        number_type: :activerecord.attributes.phone.number_type
+
+      location/regular_schedules:
+        weekday: 'Weekday'
+
       mail_address:
-        state_province: 'State'
+        <<: *address_attributes
+
+      organization:
+        alternate_name: 'Alternate Name'
+        date_incorporated: 'Date of Incorporation'
+        funding_sources: 'Funding Sources'
+        legal_status: 'Legal Status'
+        phones: 'Phone Numbers'
+        tax_id: 'Tax Identifier'
+        tax_status: 'Tax Status'
+        website: 'Organization Website'
+
+      organization/phones:
+        number: :activerecord.attributes.phone.number
+        number_type: :activerecord.attributes.phone.number_type
+
+      phone:
+        country_prefix: 'Country Prefix Code'
+        number: 'Number'
+        number_type: 'Number Type'
+        vanity_number: 'Vanity Number'
+
+      program:
+        alternate_name: 'Alternate Name'
+
+      service:
+        alternate_name: 'Alternate Name'
+        application_process: 'Application Process'
+        funding_sources: 'Funding Sources'
+        interpretation_services: 'Interpretation Services'
+        phones: 'Phone Numbers'
+        program_id: 'Service Program'
+        service_areas: 'Service Areas'
+        wait_time: 'Wait Time'
+        website: 'Service Website'
+
+      service/phones:
+        number: :activerecord.attributes.phone.number
+        number_type: :activerecord.attributes.phone.number_type
 
   admin:
     api_location: 'San Mateo County'
@@ -103,6 +189,9 @@ en:
 
         phones:
           description: 'If the phone number belongs to a contact, please move it to the existing contact, or add a new contact.'
+
+        holiday_schedule_fields:
+          enter_hours: 'If open, enter the opening and closing hours below'
 
         regular_schedule_fields:
           weekday:
@@ -255,8 +344,43 @@ en:
       invalid_url: 'is not a valid URL'
       invalid_weekday: 'is not a valid weekday'
       invalid_zip: 'is not a valid ZIP code'
-      no_address: "Unless it's virtual, a location must have an address."
+      no_address: "must be provided unless a Location is virtual"
       not_an_array: 'is not an Array.'
+
+  helpers:
+    label:
+      address: &address_helper_labels
+        state_province: 'State (2-letter abbreviation)'
+        country: 'ISO 3361-1 2-letter Country Code'
+
+      holiday_schedule:
+        closed: 'Closed or open during the above dates?'
+
+      location:
+        admin_emails: 'Add an admin to this location'
+        name: 'Location Name'
+
+      mail_address:
+        <<: *address_helper_labels
+
+      organization:
+        name: 'Organization Name'
+
+      phone:
+        country_prefix: 'Country Prefix Code (for example: 1)'
+        extension: 'Extension (numbers only)'
+        number_type: 'Number Type (Fax, Hotline, Voice, SMS, or TTY)'
+        vanity_number: 'Vanity Number (for example: 650-123-HELP)'
+
+      program:
+        name: 'Program Name'
+        organization_id: 'Choose an organization to create this program for.'
+
+      service:
+        name: 'Service Name'
+
+      user:
+        password_confirmation: 'Confirm password'
 
   titles:
     brand: "Ohana API"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,18 @@ en:
 
     locations:
       forms:
+        accessibility:
+          description: 'Which accessibility amenities are available at this location?'
+
+        address:
+          description: 'The physical location.'
+
+        admin_emails:
+          description: 'Which email addresses should be allowed to update and delete this location?'
+
+        description:
+          description: "A description of the location's services."
+
         languages:
           placeholder: 'Select one or more languages'
 
@@ -89,33 +101,112 @@ en:
           number_type:
             prompt: 'Choose an option'
 
+        phones:
+          description: 'If the phone number belongs to a contact, please move it to the existing contact, or add a new contact.'
+
         regular_schedule_fields:
           weekday:
             include_blank: 'Day'
+
+        short_desc:
+          description: 'A short summary of the description of services.'
+
+        transportation:
+          description: 'What public transportation options are nearby? (Bus stops, train stations, etc.)'
+
+        virtual:
+          description: 'Does this location have a physical address?'
+
+    organizations:
+      forms:
+        accreditations:
+          description: 'You can enter multiple terms in this box by pressing the comma key after each one.'
+
+        date_incorporated:
+          description: 'The date the organization was incorporated.'
+
+        description:
+          description: 'A description of what the organization does.'
+
+        legal_status:
+          description: 'The conditions this organization is operating under (e.g. non-profit, private corporation or a government organization).'
+
+        licenses:
+          description: 'You can enter multiple terms in this box by pressing the comma key after each one.'
+
+        tax_id:
+          description: 'Tax identifier such as the Federal Employer Identification Number.'
+
+        tax_status:
+          description: 'Internal Revenue Service tax designation, such as 501(c)(3).'
 
     services:
       forms:
         accepted_payments:
           placeholder: 'Select one or more payment methods'
 
+        application_process:
+          description: 'How does a client apply to receive services, if applicable?'
+
+        audience:
+          description: 'What groups are served, if not everyone?'
+
+        categories:
+          description: 'What categories best describe this service?'
+
+        description:
+          description: 'A description of the service.'
+
+        eligibility:
+          description: 'What criteria must served groups meet to receive service?'
+
+        fees:
+          description: 'Are there any fees to receive this service?'
+
+        interpretation_services:
+          description: 'What kind of interpretation services are available?'
+
+        keywords:
+          description: >
+            The best way to ensure a service appears in search results is to write
+            a detailed and accurate service description. If certain words or phrases
+            cannot be part of the description, such as common misspellings, then the
+            keywords field is where you can add them. You can enter multiple
+            keywords in this box by pressing the comma key after each one.
+
         languages:
           placeholder: :admin.locations.forms.languages.placeholder
 
         program:
+          description: 'If this service is associated with a program, enter it below.'
           include_blank: 'This service is not part of any program'
 
         required_documents:
           placeholder: 'Select one or more required documents'
 
         service_areas:
+          description: 'What city or county does the location serve?'
           placeholder: 'Select one or more service areas'
+
+        status:
+          description: 'Is this service active, inactive, or defunct?'
+
+        wait:
+          description: 'How long on average does a client need to wait to receive services?'
 
     shared:
       forms:
+        alternate_name:
+          description: 'Is this %{type} known by another name?'
+
         choose_org:
           placeholder: 'Choose an organization'
 
+        email:
+          description: "The %{type}'s general email."
+
         funding_sources:
+          description: 'How is this %{type} funded?'
           placeholder: 'Select one or more funding sources'
 
   enumerize:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,14 @@ en:
         languages:
           placeholder: 'Select one or more languages'
 
+        phone_fields:
+          number_type:
+            prompt: 'Choose an option'
+
+        regular_schedule_fields:
+          weekday:
+            include_blank: 'Day'
+
     services:
       forms:
         accepted_payments:
@@ -92,6 +100,9 @@ en:
 
         languages:
           placeholder: :admin.locations.forms.languages.placeholder
+
+        program:
+          include_blank: 'This service is not part of any program'
 
         required_documents:
           placeholder: 'Select one or more required documents'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,7 +62,7 @@ en:
       add_phone: 'Add a new phone number'
       delete_phone: 'Delete this phone permanently'
       add_hours_of_operation: 'Add hours of operation'
-      add_holiday_schedule: 'Add hoiday schedule'
+      add_holiday_schedule: 'Add holiday schedule'
       remove_holiday_schedule: 'Remove this holiday schedule'
       add_admin: 'Add a new admin email'
       delete_admin: 'Delete this admin permanently'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,10 +24,13 @@ en:
     attributes:
       address:
         state_province: 'State'
+
       mail_address:
         state_province: 'State'
+
   admin:
     api_location: 'San Mateo County'
+
     buttons:
       organizations: 'Organizations'
       locations: 'Locations'
@@ -77,6 +80,33 @@ en:
         'Generate zip file' to 'Download zip file'.
       wait_for_zip_file: 'Please wait while the zip file is being generated.'
 
+    locations:
+      forms:
+        languages:
+          placeholder: 'Select one or more languages'
+
+    services:
+      forms:
+        accepted_payments:
+          placeholder: 'Select one or more payment methods'
+
+        languages:
+          placeholder: :admin.locations.forms.languages.placeholder
+
+        required_documents:
+          placeholder: 'Select one or more required documents'
+
+        service_areas:
+          placeholder: 'Select one or more service areas'
+
+    shared:
+      forms:
+        choose_org:
+          placeholder: 'Choose an organization'
+
+        funding_sources:
+          placeholder: 'Select one or more funding sources'
+
   enumerize:
     location:
       accessibility:
@@ -90,6 +120,7 @@ en:
         tty: "TTY"
         wheelchair: "Wheelchair"
         wheelchair_van: "Wheelchair-accessible van"
+
     phone:
       number_type:
         fax: "Fax"
@@ -140,6 +171,7 @@ en:
     forgot_your_password: 'Forgot your password?'
     no_confirmation_instructions: "Didn't receive confirmation instructions?"
     no_unlock_instructions: "Didn't receive unlock instructions?"
+
   buttons:
     update: 'Update'
     cancel_my_account: 'Cancel my account'
@@ -151,6 +183,7 @@ en:
     register_a_new_applicaiton: 'Register a new application'
     update_application: 'Update application'
     delete_application: 'Delete application'
+
   links:
     register_a_new_application: 'Register a new application'
     view: 'view'

--- a/spec/api/delete_address_spec.rb
+++ b/spec/api/delete_address_spec.rb
@@ -50,7 +50,7 @@ describe 'DELETE /locations/:location/address/:id' do
     )
     expect(response).to have_http_status(422)
     expect(json['errors'].first['address']).
-      to eq(["Unless it's virtual, a location must have an address."])
+      to eq(['must be provided unless a Location is virtual'])
   end
 
   it "doesn't delete the address if the location & address IDs don't match" do

--- a/spec/features/admin/locations/create_location_spec.rb
+++ b/spec/features/admin/locations/create_location_spec.rb
@@ -24,7 +24,7 @@ feature 'Create a new location' do
 
   scenario 'without any required fields' do
     click_button I18n.t('admin.buttons.create_location')
-    expect(page).to have_content "Unless it's virtual, a location must have an address."
+    expect(page).to have_content 'Street Address must be provided unless a Location is virtual'
     expect(page).to have_content "Description can't be blank for Location"
     expect(page).to have_content "Name can't be blank for Location"
     expect(page).to have_content "Organization can't be blank for Location"

--- a/spec/features/admin/locations/update_address_spec.rb
+++ b/spec/features/admin/locations/update_address_spec.rb
@@ -41,14 +41,14 @@ feature "Updating a location's address with invalid values" do
     update_street_address(address_1: '', city: 'fair', state_province: 'VA',
                           postal_code: '12345', country: 'US')
     click_button I18n.t('admin.buttons.save_changes')
-    expect(page).to have_content "address 1 can't be blank for Address"
+    expect(page).to have_content "Street (Line 1) can't be blank for Address"
   end
 
   scenario 'with an empty city' do
     update_street_address(address_1: '123', city: '', state_province: 'VA',
                           postal_code: '12345', country: 'US')
     click_button I18n.t('admin.buttons.save_changes')
-    expect(page).to have_content "city can't be blank for Address"
+    expect(page).to have_content "City can't be blank for Address"
   end
 
   scenario 'with an empty state' do
@@ -62,14 +62,14 @@ feature "Updating a location's address with invalid values" do
     update_street_address(address_1: '123', city: 'Belmont', state_province: 'CA',
                           postal_code: '')
     click_button I18n.t('admin.buttons.save_changes')
-    expect(page).to have_content "postal code can't be blank for Address"
+    expect(page).to have_content "ZIP Code can't be blank for Address"
   end
 
   scenario 'with an empty country' do
     update_street_address(address_1: '123', city: 'Belmont', state_province: 'CA',
                           postal_code: '12345')
     click_button I18n.t('admin.buttons.save_changes')
-    expect(page).to have_content "country can't be blank for Address"
+    expect(page).to have_content "Country Code can't be blank for Address"
   end
 
   scenario 'with an invalid state' do
@@ -104,6 +104,6 @@ feature 'Remove a street address' do
   scenario 'from a non-virtual location', :js do
     remove_street_address
     expect(page).
-      to have_content "Unless it's virtual, a location must have an address."
+      to have_content 'Street Address must be provided unless a Location is virtual'
   end
 end

--- a/spec/features/admin/locations/update_admin_emails_spec.rb
+++ b/spec/features/admin/locations/update_admin_emails_spec.rb
@@ -44,7 +44,7 @@ feature 'Update admin_emails' do
                    all(:xpath, "//input[@name='location[admin_emails][]']")
     fill_in admin_emails[-1][:id], with: 'Alexandria'
     click_button I18n.t('admin.buttons.save_changes')
-    total_fields_with_errors = page.all(:css, '.field_with_errors')
+    total_fields_with_errors = page.all(:css, '.field_with_errors input')
     expect(total_fields_with_errors.length).to eq 1
   end
 

--- a/spec/features/admin/locations/update_mail_address_spec.rb
+++ b/spec/features/admin/locations/update_mail_address_spec.rb
@@ -37,7 +37,7 @@ feature 'Updating mailing address' do
   scenario 'when leaving location without address or mail address', :js do
     remove_street_address
     expect(page).
-      to have_content "Unless it's virtual, a location must have an address."
+      to have_content 'Street Address must be provided unless a Location is virtual'
   end
 end
 
@@ -59,14 +59,14 @@ feature 'Updating mailing address with invalid values' do
     update_mailing_address(address_1: '', city: 'fair', state_province: 'VA',
                            postal_code: '12345', country: 'US')
     click_button I18n.t('admin.buttons.save_changes')
-    expect(page).to have_content "address 1 can't be blank for Mail Address"
+    expect(page).to have_content "Street (Line 1) can't be blank for Mail Address"
   end
 
   scenario 'with an empty city' do
     update_mailing_address(address_1: '123', city: '', state_province: 'VA',
                            postal_code: '12345', country: 'US')
     click_button I18n.t('admin.buttons.save_changes')
-    expect(page).to have_content "city can't be blank for Mail Address"
+    expect(page).to have_content "City can't be blank for Mail Address"
   end
 
   scenario 'with an empty state' do
@@ -80,14 +80,14 @@ feature 'Updating mailing address with invalid values' do
     update_mailing_address(address_1: '123', city: 'Belmont', state_province: 'CA',
                            postal_code: '', country: 'US')
     click_button I18n.t('admin.buttons.save_changes')
-    expect(page).to have_content "postal code can't be blank for Mail Address"
+    expect(page).to have_content "ZIP Code can't be blank for Mail Address"
   end
 
   scenario 'with an empty country' do
     update_mailing_address(address_1: '123', city: 'Belmont', state_province: 'CA',
                            postal_code: '12345')
     click_button I18n.t('admin.buttons.save_changes')
-    expect(page).to have_content "country can't be blank for Mail Address"
+    expect(page).to have_content "Country Code can't be blank for Mail Address"
   end
 
   scenario 'with an invalid state' do

--- a/spec/features/admin/locations/update_phone_numbers_spec.rb
+++ b/spec/features/admin/locations/update_phone_numbers_spec.rb
@@ -77,7 +77,7 @@ feature 'Update phones' do
       fill_in all_phones[-1][:id], with: 'Department'
     end
     click_button I18n.t('admin.buttons.save_changes')
-    expect(page).to have_content "number can't be blank for Phone"
+    expect(page).to have_content "Number can't be blank for Phone"
   end
 
   scenario 'delete second phone', :js do
@@ -134,7 +134,7 @@ feature 'Update phones' do
   scenario 'with an empty number' do
     update_phone(number: '')
     click_button I18n.t('admin.buttons.save_changes')
-    expect(page).to have_content "number can't be blank for Phone"
+    expect(page).to have_content "Number can't be blank for Phone"
   end
 
   scenario 'with an invalid number' do

--- a/spec/features/admin/locations/visit_location_spec.rb
+++ b/spec/features/admin/locations/visit_location_spec.rb
@@ -75,7 +75,10 @@ feature 'Visiting a specific location' do
       Organization.find_each(&:destroy)
       login_super_admin
       visit('/admin/locations/new')
-      expect(page).to have_content 'Choose an organization'
+      expect(page).to have_css(
+        'input#org-name[type="hidden"][data-placeholder="Choose an organization"]',
+        visible: false
+      )
     end
   end
 end

--- a/spec/features/admin/organizations/update_phone_numbers_spec.rb
+++ b/spec/features/admin/organizations/update_phone_numbers_spec.rb
@@ -77,7 +77,7 @@ feature 'Update phones' do
       fill_in all_phones[-1][:id], with: 'Department'
     end
     click_button I18n.t('admin.buttons.save_changes')
-    expect(page).to have_content "number can't be blank for Phone"
+    expect(page).to have_content "Number can't be blank for Phone"
   end
 end
 
@@ -110,7 +110,7 @@ feature 'Update phones' do
   scenario 'with an empty number' do
     update_phone(number: '')
     click_button I18n.t('admin.buttons.save_changes')
-    expect(page).to have_content "number can't be blank for Phone"
+    expect(page).to have_content "Number can't be blank for Phone"
   end
 
   scenario 'with an invalid number' do

--- a/spec/features/create_new_api_application_spec.rb
+++ b/spec/features/create_new_api_application_spec.rb
@@ -34,7 +34,7 @@ feature 'Creating a new API Application' do
   scenario 'with blank fields' do
     create_api_app('', '', '')
     expect(page).to have_content "Name can't be blank"
-    expect(page).to have_content "Main url can't be blank"
+    expect(page).to have_content "Main URL can't be blank"
     expect(page).to_not have_content 'API Token:'
   end
 

--- a/spec/features/update_api_application_spec.rb
+++ b/spec/features/update_api_application_spec.rb
@@ -31,7 +31,7 @@ feature 'Update an existing API Application' do
   scenario 'with blank fields' do
     update_api_app('', '', '')
     expect(page).to have_content "Name can't be blank"
-    expect(page).to have_content "Main url can't be blank"
+    expect(page).to have_content "Main URL can't be blank"
     expect(page).to have_button I18n.t('buttons.update_application')
     expect(page).to have_content 'API Token'
   end

--- a/spec/lib/holiday_schedule_importer_spec.rb
+++ b/spec/lib/holiday_schedule_importer_spec.rb
@@ -42,7 +42,7 @@ describe HolidayScheduleImporter do
     context 'when the holiday_schedule content is not valid' do
       let(:content) { invalid_content }
 
-      errors = ["Line 2: Closes at can't be blank for Holiday Schedule when " \
+      errors = ["Line 2: Closes At can't be blank for Holiday Schedule when " \
         "open on that day"]
 
       its(:errors) { is_expected.to eq(errors) }
@@ -60,8 +60,8 @@ describe HolidayScheduleImporter do
     context 'when the date is not valid' do
       let(:content) { invalid_date }
 
-      errors = ["Line 2: End date 13/27/2014 is not a valid date, " \
-                "End date can't be blank for Holiday Schedule"]
+      errors = ["Line 2: End Date 13/27/2014 is not a valid date, " \
+                "End Date can't be blank for Holiday Schedule"]
 
       its(:errors) { is_expected.to eq(errors) }
     end
@@ -178,7 +178,7 @@ describe HolidayScheduleImporter do
           with("\n===> Importing invalid_holiday_schedule.csv")
 
         expect(Kernel).to receive(:puts).
-          with("Line 2: Closes at can't be blank for Holiday Schedule when open on that day")
+          with("Line 2: Closes At can't be blank for Holiday Schedule when open on that day")
 
         path = Rails.root.join('spec/support/fixtures/invalid_holiday_schedule.csv')
         HolidayScheduleImporter.check_and_import_file(path)

--- a/spec/lib/location_importer_spec.rb
+++ b/spec/lib/location_importer_spec.rb
@@ -66,7 +66,7 @@ describe LocationImporter do
       let(:content) { valid_content }
       let(:address) { invalid_address }
 
-      errors = ["Line 2: Address city can't be blank for Address"]
+      errors = ["Line 2: City can't be blank for Address"]
 
       its(:errors) { is_expected.to eq(errors) }
     end
@@ -75,7 +75,7 @@ describe LocationImporter do
       let(:content) { valid_content }
       let(:address) { missing_address }
 
-      errors = ["Line 2: Address Unless it's virtual, a location must have an address."]
+      errors = ['Line 2: Street Address must be provided unless a Location is virtual']
 
       its(:errors) { is_expected.to eq(errors) }
     end
@@ -194,10 +194,10 @@ describe LocationImporter do
     context 'with invalid data' do
       it 'outputs error message' do
         expect(Kernel).to receive(:puts).ordered.
-          with("Line 2: Address city can't be blank for Address, Name can't be blank for Location")
+          with("Line 2: City can't be blank for Address, Name can't be blank for Location")
 
         expect(Kernel).to receive(:puts).ordered.
-          with("Line 3: Address Unless it's virtual, a location must have an address.")
+          with('Line 3: Street Address must be provided unless a Location is virtual')
 
         path = Rails.root.join('spec/support/fixtures/invalid_location.csv')
         address_path = Rails.root.join('spec/support/fixtures/invalid_address.csv')
@@ -208,7 +208,7 @@ describe LocationImporter do
     context 'when only address is invalid' do
       it 'outputs error message' do
         expect(Kernel).to receive(:puts).
-          with("Line 2: Address city can't be blank for Address")
+          with("Line 2: City can't be blank for Address")
 
         path = Rails.root.join('spec/support/fixtures/valid_location.csv')
         address_path = Rails.root.join('spec/support/fixtures/invalid_address.csv')

--- a/spec/lib/mail_address_importer_spec.rb
+++ b/spec/lib/mail_address_importer_spec.rb
@@ -36,7 +36,7 @@ describe MailAddressImporter do
     context 'when the mail_address content is not valid' do
       let(:content) { invalid_content }
 
-      errors = ["Line 2: Address 1 can't be blank for Mail Address"]
+      errors = ["Line 2: Street (Line 1) can't be blank for Mail Address"]
 
       its(:errors) { is_expected.to eq(errors) }
     end
@@ -122,7 +122,7 @@ describe MailAddressImporter do
           with("\n===> Importing invalid_mail_address.csv")
 
         expect(Kernel).to receive(:puts).
-          with("Line 2: Address 1 can't be blank for Mail Address")
+          with("Line 2: Street (Line 1) can't be blank for Mail Address")
 
         path = Rails.root.join('spec/support/fixtures/invalid_mail_address.csv')
         MailAddressImporter.check_and_import_file(path)

--- a/spec/lib/organization_importer_spec.rb
+++ b/spec/lib/organization_importer_spec.rb
@@ -35,7 +35,7 @@ describe OrganizationImporter do
     context 'when the date is not valid' do
       let(:content) { invalid_date }
 
-      errors = ['Line 2: Date incorporated 24/2/70 is not a valid date']
+      errors = ['Line 2: Date of Incorporation 24/2/70 is not a valid date']
 
       its(:errors) { is_expected.to eq(errors) }
     end

--- a/spec/lib/phone_importer_spec.rb
+++ b/spec/lib/phone_importer_spec.rb
@@ -37,7 +37,7 @@ describe PhoneImporter do
     context 'when the phone content is not valid' do
       let(:content) { invalid_content }
 
-      errors = ["Line 2: Number type can't be blank for Phone"]
+      errors = ["Line 2: Number Type can't be blank for Phone"]
 
       its(:errors) { is_expected.to eq(errors) }
     end
@@ -169,7 +169,7 @@ describe PhoneImporter do
           with("\n===> Importing invalid_phone.csv")
 
         expect(Kernel).to receive(:puts).
-          with("Line 2: Number type can't be blank for Phone")
+          with("Line 2: Number Type can't be blank for Phone")
 
         path = Rails.root.join('spec/support/fixtures/invalid_phone.csv')
         PhoneImporter.check_and_import_file(path)


### PR DESCRIPTION
This PR expands the use of i18n in the Ohana API admin. The following types of strings have been moved to the locale file:

* Placeholder text (including Select2 placeholders and Rails `include_blank` and `prompt` string)
* Field descriptions (i.e. `%p.desc` and `%span.desc` strings)

For these strings, I have made heavy use of the Rails ["lazy lookup"](http://guides.rubyonrails.org/i18n.html#lazy-lookup) i18n mechanism, using dot-prefixed keys to access localizations that are scoped to the calling view. I also made use of a seldom-used "alias" feature of the `i18n` library by using a colon-prefixed value to share the value of one of the i18n strings in two partials.

In addition to the placeholder changes, I started to look at moving all field labels to i18n as well (using a combination of the `*.activerecord.attributes` and `*.helpers.label` scopes as appropriate). However, there are quite a few labels that are not using i18n and I thought I'd check to see if you're amenable to this change before I spent any more time on this.

The initial motivation for this PR was to rename "service areas" as "neighborhoods" in a possible Ohana deployment for the LA Promise Zone initiative. That isn't yet possible since I haven't dealt with the localization of `Service#service_areas`, but there is a clear path forward to making it possible.

In terms of customizing this for downstream Ohana deployments, that can either be done by modifying `en.yml` directly in the forked code base, or by adding an additional i18n file to avoid future merge conflicts (e.g. `local-overrides.en.yml`).