### PR TITLE
Specify allowed hosts for assets and URLs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,9 @@ jobs:
           ADMIN_APP_TOKEN: testing123
           API_PATH: api
           ADMIN_PATH: admin
+          ASSET_HOST: example.com
           DEFAULT_PER_PAGE: 30
+          DOMAIN_NAME: example.com
           MAX_PER_PAGE: 50
 
       # Specify service dependencies here if necessary

--- a/.reek
+++ b/.reek
@@ -12,6 +12,9 @@ IrresponsibleModule:
 NestedIterators:
   exclude:
     - Admin::OrganizationsController#index
+NilCheck:
+  exclude:
+    - ConfigValidator#required_keys_with_empty_values
 TooManyMethods:
   exclude:
     - Admin::CsvController
@@ -28,6 +31,7 @@ UtilityFunction:
   exclude:
     - Admin::ServicesController#program_ids_for
     - Admin::CsvController#zip_file_name
+    - ConfigValidator#empty_keys_warning
 'spec':
   DataClump:
     enabled: false

--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -40,7 +40,7 @@ class Admin
 
       if @contact.save
         flash[:notice] = "Contact '#{@contact.name}' was successfully created."
-        redirect_to admin_location_path(@location)
+        redirect_to admin_location_url(@location)
       else
         render :new
       end
@@ -53,7 +53,7 @@ class Admin
       authorize location
 
       contact.destroy
-      redirect_to admin_location_path(location),
+      redirect_to admin_location_url(location),
                   notice: "Contact '#{contact.name}' was successfully deleted."
     end
 

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -3,7 +3,7 @@ class Admin
     layout 'admin'
 
     def index
-      redirect_to new_session_path(:admin) unless admin_signed_in?
+      redirect_to new_admin_session_url unless admin_signed_in?
       @orgs = policy_scope(Organization) if current_admin
     end
   end

--- a/app/controllers/admin/locations_controller.rb
+++ b/app/controllers/admin/locations_controller.rb
@@ -53,7 +53,7 @@ class Admin
       authorize location
 
       location.destroy
-      redirect_to admin_locations_path
+      redirect_to admin_locations_url
     end
 
     private

--- a/app/controllers/admin/organization_contacts_controller.rb
+++ b/app/controllers/admin/organization_contacts_controller.rb
@@ -40,7 +40,7 @@ class Admin
 
       if @contact.save
         flash[:notice] = "Contact '#{@contact.name}' was successfully created."
-        redirect_to admin_organization_path(@organization)
+        redirect_to admin_organization_url(@organization)
       else
         render :new
       end
@@ -51,7 +51,7 @@ class Admin
       authorize contact
 
       contact.destroy
-      redirect_to admin_organization_path(contact.organization),
+      redirect_to admin_organization_url(contact.organization),
                   notice: "Contact '#{contact.name}' was successfully deleted."
     end
 

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -59,7 +59,7 @@ class Admin
       organization = Organization.find(params[:id])
       authorize organization
       organization.destroy
-      redirect_to admin_organizations_path
+      redirect_to admin_organizations_url
     end
 
     private

--- a/app/controllers/admin/programs_controller.rb
+++ b/app/controllers/admin/programs_controller.rb
@@ -50,7 +50,7 @@ class Admin
       program = Program.find(params[:id])
       authorize program
       program.destroy
-      redirect_to admin_programs_path
+      redirect_to admin_programs_url
     end
 
     private

--- a/app/controllers/admin/registrations_controller.rb
+++ b/app/controllers/admin/registrations_controller.rb
@@ -11,12 +11,12 @@ class Admin
       devise_parameter_sanitizer.permit(:account_update, keys: [:name])
     end
 
-    def after_inactive_sign_up_path_for(_resource)
-      new_admin_session_path
+    def after_inactive_sign_up_url_for(_resource)
+      new_admin_session_url
     end
 
     def after_update_path_for(_resource)
-      edit_admin_registration_path
+      edit_admin_registration_url
     end
   end
 end

--- a/app/controllers/admin/service_contacts_controller.rb
+++ b/app/controllers/admin/service_contacts_controller.rb
@@ -41,7 +41,7 @@ class Admin
       authorize location
 
       if @contact.save
-        redirect_to admin_location_service_path(location, @service),
+        redirect_to admin_location_service_url(location, @service),
                     notice: "Contact '#{@contact.name}' was successfully created."
       else
         render :new
@@ -56,7 +56,7 @@ class Admin
       authorize location
 
       contact.destroy
-      redirect_to admin_location_service_path(location, service),
+      redirect_to admin_location_service_url(location, service),
                   notice: "Contact '#{contact.name}' was successfully deleted."
     end
 

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -43,7 +43,7 @@ class Admin
       prepare_and_authorize_service_creation
 
       if @service.save
-        redirect_to admin_location_path(@location),
+        redirect_to admin_location_url(@location),
                     notice: "Service '#{@service.name}' was successfully created."
       else
         render :new
@@ -54,7 +54,7 @@ class Admin
       service = Service.find(params[:id])
       authorize service.location
       service.destroy
-      redirect_to admin_locations_path
+      redirect_to admin_locations_url
     end
 
     private

--- a/app/controllers/api_applications_controller.rb
+++ b/app/controllers/api_applications_controller.rb
@@ -21,7 +21,7 @@ class ApiApplicationsController < ApplicationController
     @api_application = current_user.api_applications.new(api_application_params)
 
     if @api_application.save
-      redirect_to edit_api_application_path(@api_application),
+      redirect_to edit_api_application_url(@api_application),
                   notice: 'Application was successfully created.'
     else
       render :new
@@ -33,7 +33,7 @@ class ApiApplicationsController < ApplicationController
     @api_application = current_user.api_applications.find(params[:id])
 
     if @api_application.update_attributes(api_application_params)
-      redirect_to edit_api_application_path(@api_application),
+      redirect_to edit_api_application_url(@api_application),
                   notice: 'Application was successfully updated.'
     else
       render :edit
@@ -44,7 +44,7 @@ class ApiApplicationsController < ApplicationController
   def destroy
     api_application = current_user.api_applications.find(params[:id])
     api_application.destroy
-    redirect_to api_applications_path,
+    redirect_to api_applications_url,
                 notice: 'Application was successfully deleted.'
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,18 +18,22 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(resource)
     return root_url if resource.is_a?(User)
-    return admin_dashboard_path if resource.is_a?(Admin)
+    return admin_dashboard_url if resource.is_a?(Admin)
   end
 
   def after_sign_out_path_for(resource)
-    return root_path if resource == :user
-    return admin_dashboard_path if resource == :admin
+    return root_url if resource == :user
+    return new_admin_session_url if resource == :admin
   end
 
   layout :layout_by_resource
 
   def pundit_user
     current_admin
+  end
+
+  def default_url_options
+    { host: DefaultHost.new.call(request) }
   end
 
   private
@@ -50,7 +54,7 @@ class ApplicationController < ActionController::Base
 
   def user_not_authorized
     flash[:error] = I18n.t('admin.not_authorized')
-    redirect_to(request.referer || admin_dashboard_path)
+    redirect_to(request.referer || admin_dashboard_url)
   end
 
   protected

--- a/app/controllers/concerns/private_registration.rb
+++ b/app/controllers/concerns/private_registration.rb
@@ -29,18 +29,18 @@ module PrivateRegistration
     if is_flashing_format?
       set_flash_message :notice, :signed_up_but_unconfirmed, email: resource.email
     end
-    redirect_to path_for(resource)
+    redirect_to after_registration_url_for(resource)
   end
 
-  def path_for(resource)
-    return new_admin_session_path if resource.is_a?(Admin)
-    return new_user_session_path if resource.is_a?(User)
+  def after_registration_url_for(resource)
+    return new_admin_session_url if resource.is_a?(Admin)
+    return new_user_session_url if resource.is_a?(User)
   end
 
   def process_successful_registration
     set_flash_message :notice, :"signed_up_but_#{resource.inactive_message}" if is_flashing_format?
     expire_data_after_sign_in!
-    respond_with resource, location: after_inactive_sign_up_path_for(resource)
+    redirect_to after_registration_url_for(resource)
   end
 
   def process_unsuccessful_registration

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -12,7 +12,7 @@ class User
     end
 
     def after_update_path_for(_resource)
-      edit_user_registration_path
+      edit_user_registration_url
     end
   end
 end

--- a/app/views/admin/shared/_navigation.html.haml
+++ b/app/views/admin/shared/_navigation.html.haml
@@ -8,7 +8,7 @@
         %span.icon-bar
         %span.icon-bar
       = link_to t('titles.admin', brand: t('titles.brand')),
-                admin_dashboard_path, class: 'navbar-brand'
+                admin_dashboard_url, class: 'navbar-brand'
     %nav.collapse.navbar-collapse
       %ul.nav.navbar-nav
         = render 'admin/shared/navigation_links'

--- a/config/application.example.yml
+++ b/config/application.example.yml
@@ -160,6 +160,39 @@
 # 4. Tell the developer to send the same token in their app via the
 # `X-Api-Token` HTTP header.
 
+########################################
+#
+# DOMAIN_NAME - REQUIRED IN PRODUCTION
+#
+########################################
+# This is the domain name of your website. For example, if you deployed the app
+# to Heroku and did not set up a custom domain name, your DOMAIN_NAME will be
+# app-name.herokuapp.com, where `app-name` is the name of your own Heroku app.
+# If you have a custom domain name and you are using paths instead of subdomains
+# (example.com/admin vs admin.example.com), and if your browser includes `www`
+# in your website name when you visit it, make sure to include the `www` in
+# DOMAIN_NAME, such as www.example.com. When setting up the DNS for your custom
+# domain, make sure to redirect the naked subdomain to www, or vice versa.
+# Otherwise, some parts of the app will not work properly.
+# If you have a custom domain name and you are using subdomains, such as
+# admin.example.com, make sure to set DOMAIN_NAME to the naked domain, such
+# as example.com. Otherwise, if you set DOMAIN_NAME to www.example.com,
+# you won't be able to visit admin.example.com.
+
+########################################
+#
+# ASSET_HOST - REQUIRED IN PRODUCTION
+#
+########################################
+# This is the host that serves your assets. If you deployed the app
+# to Heroku and did not set up a separate server for assets (such as Cloudfront),
+# your ASSET_HOST should be your Heroku domain, such as app-name.herokuapp.com.
+# If you have a custom domain, set ASSET_HOST to the same value as DOMAIN_NAME.
+# For more advanced users, if you will be using a CDN, you will need to replace
+# AssetHosts#call with your own implementation.
+# See: http://api.rubyonrails.org/classes/ActionView/Helpers/AssetUrlHelper.html
+# for examples.
+
 ###########################
 #
 # SETTINGS FOR DEVELOPMENT
@@ -170,8 +203,10 @@ development:
   API_PATH: api
   ADMIN_SUBDOMAIN:
   ADMIN_PATH: admin
+  ASSET_HOST: lvh.me
   DEV_SUBDOMAIN:
   DEFAULT_PER_PAGE: '30'
+  DOMAIN_NAME: lvh.me
   MAX_PER_PAGE: '50'
 
 ###############################################################################
@@ -186,8 +221,10 @@ production:
   API_PATH: api
   ADMIN_SUBDOMAIN:
   ADMIN_PATH: admin
+  ASSET_HOST:
   DEV_SUBDOMAIN:
   DEFAULT_PER_PAGE: '30'
+  DOMAIN_NAME:
   MAX_PER_PAGE: '50'
   EXPIRES_IN: '1'
   TLD_LENGTH: '2'
@@ -203,7 +240,9 @@ test:
   API_PATH: api
   ADMIN_SUBDOMAIN:
   ADMIN_PATH: admin
+  ASSET_HOST: example.com
   DEV_SUBDOMAIN:
   DEFAULT_PER_PAGE: '30'
+  DOMAIN_NAME: example.com
   MAX_PER_PAGE: '50'
   ADMIN_APP_TOKEN: testing123

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -24,6 +24,10 @@ Rails.application.configure do
   #   entitystore: client
   # }
 
+  # Specify the asset_host to prevent host header injection.
+  require 'asset_hosts'
+  config.action_controller.asset_host = AssetHosts.new
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = { host: 'lvh.me:8080' }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,6 +56,9 @@ Rails.application.configure do
   config.assets.digest = true
 
   config.action_controller.perform_caching = true
+  # Specify the asset_host to prevent host header injection.
+  require 'asset_hosts'
+  config.action_controller.asset_host = AssetHosts.new
 
   config.cache_store = :dalli_store
   client = Dalli::Client.new((ENV['MEMCACHIER_SERVERS'] || '').split(','),
@@ -77,9 +80,6 @@ Rails.application.configure do
   }
   config.static_cache_control = 'public, max-age=2592000'
   # --------------------------------------------------------------------------
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -1,5 +1,13 @@
+require Rails.root.join('lib', 'config_validator.rb')
+
 # Define the environment variables that should be set in config/application.yml.
 # See config/application.example.yml if you don't have config/application.yml.
 Figaro.require_keys('API_PATH') if ENV['API_SUBDOMAIN'].blank?
 Figaro.require_keys('ADMIN_PATH') if ENV['ADMIN_SUBDOMAIN'].blank?
-Figaro.require_keys('DEFAULT_PER_PAGE', 'MAX_PER_PAGE')
+Figaro.require_keys(
+  'ASSET_HOST',
+  'DEFAULT_PER_PAGE',
+  'DOMAIN_NAME',
+  'MAX_PER_PAGE'
+)
+ConfigValidator.new.validate

--- a/lib/asset_hosts.rb
+++ b/lib/asset_hosts.rb
@@ -1,0 +1,39 @@
+class AssetHosts
+  def call(_source, request)
+    @request = request
+    return asset_host_with_port if host_same_as_asset_host? || unauthorized_host?
+    "#{subdomain}#{asset_host_with_port}"
+  end
+
+  private
+
+  attr_reader :request
+
+  def asset_host_with_port
+    "#{asset_host}#{port}"
+  end
+
+  def asset_host
+    @asset_host ||= Figaro.env.asset_host
+  end
+
+  def port
+    ":#{request_port}" if request_port
+  end
+
+  def request_port
+    @request_port ||= request.port
+  end
+
+  def host_same_as_asset_host?
+    request.host == asset_host
+  end
+
+  def unauthorized_host?
+    !request.host.end_with?(asset_host)
+  end
+
+  def subdomain
+    request.host.split(asset_host)[0]
+  end
+end

--- a/lib/config_validator.rb
+++ b/lib/config_validator.rb
@@ -1,0 +1,34 @@
+class ConfigValidator
+  KEYS_THAT_CANNOT_BE_EMPTY = %w[
+    ASSET_HOST
+    DEFAULT_PER_PAGE
+    DOMAIN_NAME
+    MAX_PER_PAGE
+  ].freeze
+
+  def initialize(env = ENV)
+    @env = env
+  end
+
+  def validate
+    validate_non_empty_required_keys
+  end
+
+  private
+
+  attr_reader :env
+
+  def validate_non_empty_required_keys
+    empty_keys = required_keys_with_empty_values
+    return if empty_keys.empty?
+    raise empty_keys_warning(empty_keys)
+  end
+
+  def required_keys_with_empty_values
+    KEYS_THAT_CANNOT_BE_EMPTY.select { |key| env[key]&.empty? }
+  end
+
+  def empty_keys_warning(empty_keys)
+    'These configs are required but are empty: ' + empty_keys.join(', ')
+  end
+end

--- a/lib/default_host.rb
+++ b/lib/default_host.rb
@@ -1,0 +1,13 @@
+class DefaultHost
+  def call(request)
+    host = request.host
+    return host if host.end_with?(default_host)
+    default_host
+  end
+
+  private
+
+  def default_host
+    @default_host ||= Figaro.env.domain_name
+  end
+end

--- a/spec/controllers/admin/contacts_controller_spec.rb
+++ b/spec/controllers/admin/contacts_controller_spec.rb
@@ -24,7 +24,7 @@ describe Admin::ContactsController do
 
         get :edit, location_id: @loc.id, id: @contact.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -62,7 +62,7 @@ describe Admin::ContactsController do
 
         get :new, location_id: @loc.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -89,7 +89,7 @@ describe Admin::ContactsController do
 
         post :create, location_id: @loc.id, contact: { name: 'John' }
 
-        expect(response).to redirect_to "/admin/locations/#{@loc.friendly_id}"
+        expect(response).to redirect_to admin_location_url(@loc.friendly_id)
       end
     end
 
@@ -99,7 +99,7 @@ describe Admin::ContactsController do
 
         post :create, location_id: @loc.id, contact: { name: 'John' }
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@loc.contacts).to be_empty
       end
@@ -111,7 +111,7 @@ describe Admin::ContactsController do
 
         post :create, location_id: @loc.id, contact: { name: 'John' }
 
-        expect(response).to redirect_to "/admin/locations/#{@loc.friendly_id}"
+        expect(response).to redirect_to admin_location_url(@loc.friendly_id)
         expect(@loc.contacts.last.name).to eq 'John'
       end
     end
@@ -130,7 +130,7 @@ describe Admin::ContactsController do
         post :update, location_id: @loc.id, id: @contact.id, contact: { name: 'John' }
 
         expect(response).
-          to redirect_to "/admin/locations/#{@loc.friendly_id}/contacts/#{@contact.id}"
+          to redirect_to admin_location_contact_url(@loc.friendly_id, @contact.id)
       end
     end
 
@@ -140,7 +140,7 @@ describe Admin::ContactsController do
 
         post :update, location_id: @loc.id, id: @contact.id, contact: { name: 'John' }
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@contact.reload.name).to_not eq 'John'
       end
@@ -153,7 +153,7 @@ describe Admin::ContactsController do
         post :update, location_id: @loc.id, id: @contact.id, contact: { name: 'John' }
 
         expect(response).
-          to redirect_to "/admin/locations/#{@loc.friendly_id}/contacts/#{@contact.id}"
+          to redirect_to admin_location_contact_url(@loc.friendly_id, @contact.id)
         expect(@contact.reload.name).to eq 'John'
       end
     end
@@ -171,7 +171,7 @@ describe Admin::ContactsController do
 
         delete :destroy, location_id: @loc.id, id: @contact.id
 
-        expect(response).to redirect_to "/admin/locations/#{@loc.friendly_id}"
+        expect(response).to redirect_to admin_location_url(@loc.friendly_id)
       end
     end
 
@@ -181,7 +181,7 @@ describe Admin::ContactsController do
 
         delete :destroy, location_id: @loc.id, id: @contact.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@contact.reload.name).to eq 'Moncef Belyamani'
       end
@@ -193,7 +193,7 @@ describe Admin::ContactsController do
 
         delete :destroy, location_id: @loc.id, id: @contact.id
 
-        expect(response).to redirect_to "/admin/locations/#{@loc.friendly_id}"
+        expect(response).to redirect_to admin_location_url(@loc.friendly_id)
         expect(Contact.find_by(id: @contact.id)).to be_nil
       end
     end

--- a/spec/controllers/admin/csv_controller_spec.rb
+++ b/spec/controllers/admin/csv_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Admin::CsvController do
   describe 'GET all' do
     let(:tmp_file_name) { Rails.root.join('tmp', 'archive.zip') }
-    let(:url_prefix) { 'http://test.host/admin/csv/' }
+    let(:url_prefix) { 'http://example.com/admin/csv/' }
 
     it 'performs the ZipDownload job 2 seconds later' do
       log_in_as_admin(:super_admin)
@@ -28,7 +28,7 @@ describe Admin::CsvController do
 
         get action
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end

--- a/spec/controllers/admin/locations_controller_spec.rb
+++ b/spec/controllers/admin/locations_controller_spec.rb
@@ -16,7 +16,8 @@ describe Admin::LocationsController do
           organization_id: @org.id
         }
 
-        expect(response).to redirect_to '/admin/locations/new-location'
+        location = Location.find_by(name: 'New Location')
+        expect(response).to redirect_to admin_location_url(location)
       end
     end
 
@@ -31,7 +32,7 @@ describe Admin::LocationsController do
         }
 
         expect { post :create, location: location_params }.to_not change(Location, :count)
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -48,7 +49,8 @@ describe Admin::LocationsController do
           organization_id: @org.id
         }
 
-        expect(response).to redirect_to '/admin/locations/new-location'
+        location = Location.find_by(name: 'New Location')
+        expect(response).to redirect_to admin_location_url(location)
       end
     end
   end
@@ -64,7 +66,7 @@ describe Admin::LocationsController do
 
         post :update, id: @loc.id, location: { name: 'Updated location' }
 
-        expect(response).to redirect_to "/admin/locations/#{@loc.reload.friendly_id}"
+        expect(response).to redirect_to admin_location_url(@loc.reload.friendly_id)
       end
     end
 
@@ -75,7 +77,7 @@ describe Admin::LocationsController do
 
         post :update, id: @loc.id, location: { name: 'Updated location' }
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@loc.reload.name).to_not eq 'Updated location'
       end
@@ -87,7 +89,7 @@ describe Admin::LocationsController do
 
         post :update, id: @loc.id, location: { name: 'Updated location' }
 
-        expect(response).to redirect_to "/admin/locations/#{@loc.reload.friendly_id}"
+        expect(response).to redirect_to admin_location_url(@loc.reload.friendly_id)
         expect(@loc.reload.name).to eq 'Updated location'
       end
     end
@@ -104,7 +106,7 @@ describe Admin::LocationsController do
 
         delete :destroy, id: @location.id
 
-        expect(response).to redirect_to '/admin/locations'
+        expect(response).to redirect_to admin_locations_url
       end
     end
 
@@ -115,7 +117,7 @@ describe Admin::LocationsController do
 
         expect { delete :destroy, id: @location.id }.to_not change(Location, :count)
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -126,7 +128,7 @@ describe Admin::LocationsController do
 
         delete :destroy, id: @location.id
 
-        expect(response).to redirect_to '/admin/locations'
+        expect(response).to redirect_to admin_locations_url
         expect(Location.find_by(id: @location.id)).to be_nil
       end
     end
@@ -154,7 +156,7 @@ describe Admin::LocationsController do
 
         get :edit, id: @location.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -192,7 +194,7 @@ describe Admin::LocationsController do
 
         get :new
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end

--- a/spec/controllers/admin/organization_contacts_controller_spec.rb
+++ b/spec/controllers/admin/organization_contacts_controller_spec.rb
@@ -25,7 +25,7 @@ describe Admin::OrganizationContactsController do
 
         get :edit, organization_id: @org.id, id: @contact.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -64,7 +64,7 @@ describe Admin::OrganizationContactsController do
 
         get :new, organization_id: @org.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -92,7 +92,7 @@ describe Admin::OrganizationContactsController do
 
         post :create, organization_id: @org.id, contact: { name: 'Jane' }
 
-        expect(response).to redirect_to "/admin/organizations/#{@org.friendly_id}"
+        expect(response).to redirect_to admin_organization_url(@org.friendly_id)
       end
     end
 
@@ -103,7 +103,7 @@ describe Admin::OrganizationContactsController do
 
         post :create, organization_id: @org.id, contact: { name: 'Jane' }
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@org.contacts).to be_empty
       end
@@ -117,7 +117,7 @@ describe Admin::OrganizationContactsController do
 
         post :create, organization_id: organization.id, contact: { name: 'Jane' }
 
-        expect(response).to redirect_to "/admin/organizations/#{organization.friendly_id}"
+        expect(response).to redirect_to admin_organization_url(organization.friendly_id)
         expect(organization.contacts.last.name).to eq 'Jane'
       end
     end
@@ -137,7 +137,7 @@ describe Admin::OrganizationContactsController do
         post :update, organization_id: @org.id, id: @contact.id, contact: { name: 'Jane' }
 
         expect(response).
-          to redirect_to "/admin/organizations/#{@org.friendly_id}/contacts/#{@contact.id}"
+          to redirect_to admin_organization_contact_url(@org.friendly_id, @contact.id)
       end
     end
 
@@ -148,7 +148,7 @@ describe Admin::OrganizationContactsController do
 
         post :update, organization_id: @org.id, id: @contact.id, contact: { name: 'Jane' }
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@contact.reload.name).to_not eq 'Jane'
       end
@@ -161,7 +161,7 @@ describe Admin::OrganizationContactsController do
         post :update, organization_id: @org.id, id: @contact.id, contact: { name: 'Jane' }
 
         expect(response).
-          to redirect_to "/admin/organizations/#{@org.friendly_id}/contacts/#{@contact.id}"
+          to redirect_to admin_organization_contact_url(@org.friendly_id, @contact.id)
         expect(@contact.reload.name).to eq 'Jane'
       end
     end
@@ -180,7 +180,7 @@ describe Admin::OrganizationContactsController do
 
         delete :destroy, organization_id: @org.id, id: @contact.id
 
-        expect(response).to redirect_to "/admin/organizations/#{@org.friendly_id}"
+        expect(response).to redirect_to admin_organization_url(@org.friendly_id)
       end
     end
 
@@ -191,7 +191,7 @@ describe Admin::OrganizationContactsController do
 
         delete :destroy, organization_id: @org.id, id: @contact.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@contact.reload.name).to eq 'Moncef Belyamani'
       end
@@ -203,7 +203,7 @@ describe Admin::OrganizationContactsController do
 
         delete :destroy, organization_id: @org.id, id: @contact.id
 
-        expect(response).to redirect_to "/admin/organizations/#{@org.friendly_id}"
+        expect(response).to redirect_to admin_organization_url(@org.friendly_id)
         expect(Contact.find_by(id: @contact.id)).to be_nil
       end
     end

--- a/spec/controllers/admin/organizations_controller_spec.rb
+++ b/spec/controllers/admin/organizations_controller_spec.rb
@@ -17,7 +17,7 @@ describe Admin::OrganizationsController do
 
         expect { post :create, organization: attrs }.to change(Organization, :count)
 
-        expect(response).to redirect_to '/admin/organizations'
+        expect(response).to redirect_to admin_organizations_url
       end
     end
 
@@ -27,7 +27,7 @@ describe Admin::OrganizationsController do
 
         expect { post :create, organization: attrs }.to_not change(Organization, :count)
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -54,7 +54,7 @@ describe Admin::OrganizationsController do
 
         post :update, id: @org.id, organization: attrs
 
-        expect(response).to redirect_to "/admin/organizations/#{@org.reload.friendly_id}"
+        expect(response).to redirect_to admin_organization_url(@org.reload.friendly_id)
       end
     end
 
@@ -65,7 +65,7 @@ describe Admin::OrganizationsController do
 
         post :update, id: @org.id, organization: attrs
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@org.reload.name).to_not eq 'Updated organization'
       end
@@ -77,7 +77,7 @@ describe Admin::OrganizationsController do
 
         post :update, id: @org.id, organization: attrs
 
-        expect(response).to redirect_to "/admin/organizations/#{@org.reload.friendly_id}"
+        expect(response).to redirect_to admin_organization_url(@org.reload.friendly_id)
         expect(@org.reload.name).to eq 'Updated org'
       end
     end
@@ -95,7 +95,7 @@ describe Admin::OrganizationsController do
 
         delete :destroy, id: @organization.id
 
-        expect(response).to redirect_to '/admin/organizations'
+        expect(response).to redirect_to admin_organizations_url
       end
     end
 
@@ -106,7 +106,7 @@ describe Admin::OrganizationsController do
 
         expect { delete :destroy, id: @organization.id }.to_not change(Organization, :count)
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -117,7 +117,7 @@ describe Admin::OrganizationsController do
 
         delete :destroy, id: @organization.id
 
-        expect(response).to redirect_to '/admin/organizations'
+        expect(response).to redirect_to admin_organizations_url
         expect(Organization.find_by(id: @organization.id)).to be_nil
       end
     end
@@ -146,7 +146,7 @@ describe Admin::OrganizationsController do
 
         get :edit, id: @organization.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -179,7 +179,7 @@ describe Admin::OrganizationsController do
 
         get :new
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end

--- a/spec/controllers/admin/programs_controller_spec.rb
+++ b/spec/controllers/admin/programs_controller_spec.rb
@@ -25,7 +25,7 @@ describe Admin::ProgramsController do
 
         get :edit, id: @program.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -90,7 +90,7 @@ describe Admin::ProgramsController do
 
         post :create, program: { name: 'New program', organization_id: @org.id }
 
-        expect(response).to redirect_to '/admin/programs'
+        expect(response).to redirect_to admin_programs_url
       end
     end
 
@@ -102,7 +102,7 @@ describe Admin::ProgramsController do
         expect { post :create, program: { name: 'New program', organization_id: @org.id } }.
           to_not change(Program, :count)
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@org.programs).to be_empty
       end
@@ -114,7 +114,7 @@ describe Admin::ProgramsController do
 
         post :create, program: { name: 'New program', organization_id: @org.id }
 
-        expect(response).to redirect_to '/admin/programs'
+        expect(response).to redirect_to admin_programs_url
       end
     end
   end
@@ -132,7 +132,7 @@ describe Admin::ProgramsController do
 
         post :update, id: @program.id, program: { name: 'Updated program' }
 
-        expect(response).to redirect_to "/admin/programs/#{@program.id}"
+        expect(response).to redirect_to admin_program_url(@program.id)
       end
     end
 
@@ -143,7 +143,7 @@ describe Admin::ProgramsController do
 
         post :update, id: @program.id, program: { name: 'Updated program' }
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@program.reload.name).to_not eq 'Updated program'
       end
@@ -155,7 +155,7 @@ describe Admin::ProgramsController do
 
         post :update, id: @program.id, program: { name: 'Updated program' }
 
-        expect(response).to redirect_to "/admin/programs/#{@program.id}"
+        expect(response).to redirect_to admin_program_url(@program.id)
         expect(@program.reload.name).to eq 'Updated program'
       end
     end
@@ -174,7 +174,7 @@ describe Admin::ProgramsController do
 
         delete :destroy, id: @program.id
 
-        expect(response).to redirect_to '/admin/programs'
+        expect(response).to redirect_to admin_programs_url
       end
     end
 
@@ -185,7 +185,7 @@ describe Admin::ProgramsController do
 
         expect { delete :destroy, id: @program.id }.to_not change(Program, :count)
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -196,7 +196,7 @@ describe Admin::ProgramsController do
 
         delete :destroy, id: @program.id
 
-        expect(response).to redirect_to '/admin/programs'
+        expect(response).to redirect_to admin_programs_url
         expect(Program.find_by(id: @program.id)).to be_nil
       end
     end

--- a/spec/controllers/admin/service_contacts_controller_spec.rb
+++ b/spec/controllers/admin/service_contacts_controller_spec.rb
@@ -25,7 +25,7 @@ describe Admin::ServiceContactsController do
 
         get :edit, location_id: @location.id, service_id: @service.id, id: @contact.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -64,7 +64,7 @@ describe Admin::ServiceContactsController do
 
         get :new, location_id: @location.id, service_id: @service.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -93,7 +93,7 @@ describe Admin::ServiceContactsController do
         post :create, location_id: @location.id, service_id: @service.id, contact: { name: 'Jane' }
 
         expect(response).
-          to redirect_to "/admin/locations/#{@location.friendly_id}/services/#{@service.id}"
+          to redirect_to admin_location_service_url(@location.friendly_id, @service.id)
       end
     end
 
@@ -104,7 +104,7 @@ describe Admin::ServiceContactsController do
 
         post :create, location_id: @location.id, service_id: @service.id, contact: { name: 'Jane' }
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@service.contacts).to be_empty
       end
@@ -117,7 +117,7 @@ describe Admin::ServiceContactsController do
         post :create, location_id: @location.id, service_id: @service.id, contact: { name: 'Jane' }
 
         expect(response).
-          to redirect_to "/admin/locations/#{@location.friendly_id}/services/#{@service.id}"
+          to redirect_to admin_location_service_url(@location.friendly_id, @service.id)
         expect(@service.contacts.last.name).to eq 'Jane'
       end
     end
@@ -140,9 +140,12 @@ describe Admin::ServiceContactsController do
           id: @contact.id, contact: { name: 'Jane' }
         )
 
-        path_prefix = "/admin/locations/#{@location.friendly_id}/services/#{@service.id}/contacts"
+        location = @location.friendly_id
+        service = @service.id
+        contact = @contact.id
 
-        expect(response).to redirect_to "#{path_prefix}/#{@contact.id}"
+        expect(response).
+          to redirect_to admin_location_service_contact_url(location, service, contact)
       end
     end
 
@@ -157,7 +160,7 @@ describe Admin::ServiceContactsController do
           id: @contact.id, contact: { name: 'Jane' }
         )
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@contact.reload.name).to_not eq 'Jane'
       end
@@ -173,9 +176,12 @@ describe Admin::ServiceContactsController do
           id: @contact.id, contact: { name: 'Jane' }
         )
 
-        path_prefix = "/admin/locations/#{@location.friendly_id}/services/#{@service.id}/contacts"
+        location = @location.friendly_id
+        service = @service.id
+        contact = @contact.id
 
-        expect(response).to redirect_to "#{path_prefix}/#{@contact.id}"
+        expect(response).
+          to redirect_to admin_location_service_contact_url(location, service, contact)
         expect(@contact.reload.name).to eq 'Jane'
       end
     end
@@ -195,7 +201,7 @@ describe Admin::ServiceContactsController do
         delete :destroy, location_id: @location.id, service_id: @service.id, id: @contact.id
 
         expect(response).
-          to redirect_to "/admin/locations/#{@location.friendly_id}/services/#{@service.id}"
+          to redirect_to admin_location_service_url(@location.friendly_id, @service.id)
       end
     end
 
@@ -206,7 +212,7 @@ describe Admin::ServiceContactsController do
 
         delete :destroy, location_id: @location.id, service_id: @service.id, id: @contact.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@contact.reload.name).to eq 'Moncef Belyamani'
       end
@@ -219,7 +225,7 @@ describe Admin::ServiceContactsController do
         delete :destroy, location_id: @location.id, service_id: @service.id, id: @contact.id
 
         expect(response).
-          to redirect_to "/admin/locations/#{@location.friendly_id}/services/#{@service.id}"
+          to redirect_to admin_location_service_url(@location.friendly_id, @service.id)
         expect(Contact.find_by(id: @contact.id)).to be_nil
       end
     end

--- a/spec/controllers/admin/services_controller_spec.rb
+++ b/spec/controllers/admin/services_controller_spec.rb
@@ -24,7 +24,7 @@ describe Admin::ServicesController do
 
         get :edit, location_id: @loc.id, id: @service.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -62,7 +62,7 @@ describe Admin::ServicesController do
 
         get :new, location_id: @loc.id
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -132,7 +132,7 @@ describe Admin::ServicesController do
         }
 
         expect(response).
-          to redirect_to "/admin/locations/#{@location.friendly_id}"
+          to redirect_to admin_location_url(@location.friendly_id)
       end
     end
 
@@ -147,7 +147,7 @@ describe Admin::ServicesController do
           }
         end.to_not change(Service, :count)
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -163,7 +163,7 @@ describe Admin::ServicesController do
         end.to change(Service, :count).by(1)
 
         expect(response).
-          to redirect_to "/admin/locations/#{@location.friendly_id}"
+          to redirect_to admin_location_url(@location.friendly_id)
       end
     end
   end
@@ -185,9 +185,8 @@ describe Admin::ServicesController do
 
         post(:update, location_id: @location.id, id: @service.id, service: @attrs)
 
-        path = "/admin/locations/#{@location.friendly_id}/services/#{@service.id}"
-
-        expect(response).to redirect_to path
+        expect(response).
+          to redirect_to admin_location_service_url(@location.friendly_id, @service.id)
       end
     end
 
@@ -198,7 +197,7 @@ describe Admin::ServicesController do
 
         post(:update, location_id: @location.id, id: @service.id, service: @attrs)
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
         expect(@service.reload.name).to_not eq 'Updated Service'
       end
@@ -210,9 +209,8 @@ describe Admin::ServicesController do
 
         post(:update, location_id: @location.id, id: @service.id, service: @attrs)
 
-        path = "/admin/locations/#{@location.friendly_id}/services/#{@service.id}"
-
-        expect(response).to redirect_to path
+        expect(response).
+          to redirect_to admin_location_service_url(@location.friendly_id, @service.id)
       end
     end
   end
@@ -229,8 +227,7 @@ describe Admin::ServicesController do
 
         delete :destroy, location_id: @location.id, id: @service.id
 
-        expect(response).
-          to redirect_to '/admin/locations'
+        expect(response).to redirect_to admin_locations_url
       end
     end
 
@@ -242,7 +239,7 @@ describe Admin::ServicesController do
         expect { delete :destroy, location_id: @location.id, id: @service.id }.
           to_not change(Service, :count)
 
-        expect(response).to redirect_to admin_dashboard_path
+        expect(response).to redirect_to admin_dashboard_url
         expect(flash[:error]).to eq(I18n.t('admin.not_authorized'))
       end
     end
@@ -253,8 +250,7 @@ describe Admin::ServicesController do
 
         delete :destroy, location_id: @location.id, id: @service.id
 
-        expect(response).
-          to redirect_to '/admin/locations'
+        expect(response).to redirect_to admin_locations_url
         expect(Service.find_by(id: @service.id)).to be_nil
       end
     end

--- a/spec/controllers/api_applications_controller_spec.rb
+++ b/spec/controllers/api_applications_controller_spec.rb
@@ -60,7 +60,7 @@ describe ApiApplicationsController do
         post :create, api_application: valid_attributes
         new_app = @user.reload.api_applications.last
         expect(response).
-          to redirect_to edit_api_application_path(new_app)
+          to redirect_to edit_api_application_url(new_app)
       end
 
       it 'generates an access token' do
@@ -110,7 +110,7 @@ describe ApiApplicationsController do
           api_application: valid_attributes
         )
         expect(response).
-          to redirect_to edit_api_application_path(api_application)
+          to redirect_to edit_api_application_url(api_application)
       end
     end
 

--- a/spec/features/admin/sign_up_spec.rb
+++ b/spec/features/admin/sign_up_spec.rb
@@ -4,6 +4,7 @@ feature 'Signing up for a new admin account' do
   scenario 'with all required fields present and valid' do
     sign_up_admin('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
     expect(page).to have_content 'activate your account'
+    expect(page).to have_content('Admin')
     expect(current_path).to eq(new_admin_session_path)
   end
 

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -4,7 +4,8 @@ feature 'Signing up' do
   scenario 'with all required fields present and valid' do
     sign_up('Moncef', 'moncef@foo.com', 'ohanatest', 'ohanatest')
     expect(page).to have_content 'activate your account'
-    expect(current_path).to eq(root_path)
+    expect(page).to_not have_content('Admin')
+    expect(current_path).to eq(new_user_session_path)
   end
 
   scenario 'with name missing' do

--- a/spec/lib/asset_hosts_spec.rb
+++ b/spec/lib/asset_hosts_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+describe AssetHosts do
+  describe '#call' do
+    let(:request_with_port) { double(host: 'example.com', port: '3000') }
+    let(:request_with_subdomain_and_port) do
+      double(host: 'admin.example.com', port: '3000')
+    end
+    let(:request) { double(host: 'example.com', port: nil) }
+    let(:request_with_unauthorized_host) do
+      double(host: 'evil.example.com.evil.com', port: nil)
+    end
+    let(:request_without_port) do
+      double(host: 'admin.example.com', port: nil)
+    end
+
+    context 'heroku domain' do
+      it 'only allows the configured asset host' do
+        allow(Figaro.env).to receive(:asset_host).and_return('app.herokuapp.com')
+        request = double(host: 'foo.herokuapp.com', port: nil)
+
+        expect(AssetHosts.new.call('image.png', request)).to eq 'app.herokuapp.com'
+      end
+    end
+
+    context 'port but no subdomains' do
+      it 'returns host with port' do
+        expect(AssetHosts.new.call('image.png', request_with_port)).to eq 'example.com:3000'
+      end
+    end
+
+    context 'subdomain with port' do
+      it 'returns the host with subdomain and port' do
+        expect(AssetHosts.new.call('image.png', request_with_subdomain_and_port)).
+          to eq 'admin.example.com:3000'
+      end
+    end
+
+    context 'no subdomains, no port' do
+      it 'returns the host' do
+        expect(AssetHosts.new.call('image.png', request)).to eq 'example.com'
+      end
+    end
+
+    context 'unauthorized host' do
+      it 'returns the default asset host' do
+        expect(AssetHosts.new.call('image.png', request_with_unauthorized_host)).
+          to eq 'example.com'
+      end
+    end
+
+    context 'subdomain, no port' do
+      it 'returns the host' do
+        expect(AssetHosts.new.call('image.png', request_without_port)).to eq 'admin.example.com'
+      end
+    end
+
+    context 'custom domain but asset host is not set to naked domain' do
+      it 'will use asset_host' do
+        allow(Figaro.env).to receive(:asset_host).and_return('www.example.com')
+        request = double(host: 'example.com', port: nil)
+
+        expect(AssetHosts.new.call('image.png', request)).to eq 'www.example.com'
+      end
+    end
+
+    context 'request made from subdomain but asset host is not set to naked domain' do
+      it 'will use asset_host' do
+        allow(Figaro.env).to receive(:asset_host).and_return('www.example.com')
+        request = double(host: 'admin.example.com', port: nil)
+
+        expect(AssetHosts.new.call('image.png', request)).to eq 'www.example.com'
+      end
+    end
+  end
+end

--- a/spec/lib/config_validator_spec.rb
+++ b/spec/lib/config_validator_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe ConfigValidator do
+  describe '#validate' do
+    let(:invalid_env) do
+      {
+        'ASSET_HOST' => '',
+        'DEFAULT_PER_PAGE' => '',
+        'DOMAIN_NAME' => '',
+        'MAX_PER_PAGE' => '',
+      }
+    end
+
+    let(:valid_env) do
+      {
+        'ASSET_HOST' => 'lvh.me',
+        'DEFAULT_PER_PAGE' => '30',
+        'DOMAIN_NAME' => 'lvh.me',
+        'MAX_PER_PAGE' => '30',
+        'DEV_SUBDOMAIN' => '',
+      }
+    end
+
+    it 'raises if one or more required key values is set to an empty string' do
+      list = 'ASSET_HOST, DEFAULT_PER_PAGE, DOMAIN_NAME, MAX_PER_PAGE'
+
+      expect { ConfigValidator.new(invalid_env).validate }.to raise_error(
+        RuntimeError, "These configs are required but are empty: #{list}"
+      )
+    end
+
+    it 'does not raise if a non-required key is empty' do
+      expect { ConfigValidator.new(valid_env).validate }.to_not raise_error
+    end
+  end
+end

--- a/spec/lib/default_host_spec.rb
+++ b/spec/lib/default_host_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe DefaultHost do
+  describe '#call' do
+    context 'heroku domain' do
+      it 'only allows the configured domain name' do
+        allow(Figaro.env).to receive(:domain_name).and_return('app.herokuapp.com')
+        request = double(host: 'foo.herokuapp.com')
+
+        expect(DefaultHost.new.call(request)).to eq 'app.herokuapp.com'
+      end
+    end
+
+    context 'custom domain with subdomain' do
+      it 'uses the full domain with subdomain' do
+        request = double(host: 'foo.example.com')
+
+        expect(DefaultHost.new.call(request)).to eq 'foo.example.com'
+      end
+    end
+
+    context 'custom domain but domain_name is not set to naked domain' do
+      it 'will not redirect properly to subdomains' do
+        allow(Figaro.env).to receive(:domain_name).and_return('www.example.com')
+        request = double(host: 'admin.example.com')
+
+        expect(DefaultHost.new.call(request)).to eq 'www.example.com'
+      end
+    end
+
+    context 'unauthorized host' do
+      it 'returns the configured domain name' do
+        request = double(host: 'test.com')
+
+        expect(DefaultHost.new.call(request)).to eq 'example.com'
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,7 @@ require 'shoulda/matchers'
 
 require 'capybara/poltergeist'
 Capybara.javascript_driver = :poltergeist
-Capybara.default_max_wait_time = 30
+Capybara.default_max_wait_time = 10
 
 Rails.logger.level = 4
 
@@ -47,4 +47,8 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = false
   # require 'active_record_spec_helper'
+
+  config.before(:each, type: :feature, js: true) do
+    allow(Figaro.env).to receive(:domain_name).and_return('127.0.0.1')
+  end
 end

--- a/spec/requests/api_applications_spec.rb
+++ b/spec/requests/api_applications_spec.rb
@@ -15,7 +15,7 @@ describe 'ApiApplications' do
       it 'returns a 200' do
         @user = FactoryBot.create(:user)
         login(@user)
-        get api_applications_path
+        get api_applications_url
         expect(response.status).to be(200)
       end
     end


### PR DESCRIPTION
**Why**: To help prevent host header injection.
See: https://github.com/ankane/secure_rails and
https://github.com/rails/rails/issues/29893