### PR TITLE
Don’t set asset host in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -24,10 +24,6 @@ Rails.application.configure do
   #   entitystore: client
   # }
 
-  # Specify the asset_host to prevent host header injection.
-  require 'asset_hosts'
-  config.action_controller.asset_host = AssetHosts.new
-
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options = { host: 'lvh.me:8080' }


### PR DESCRIPTION
**Why**: When assets are first being compiled, there is no request and the app will throw an exception because the call to AssetHosts.new only includes one argument instead of two. Specifying an asset host is not required in development.