### PR TITLE
Increase wait time for deletion specs

### DIFF
--- a/spec/features/admin/contacts/delete_contact_spec.rb
+++ b/spec/features/admin/contacts/delete_contact_spec.rb
@@ -11,7 +11,7 @@ feature 'Delete contact' do
 
   scenario 'when deleting contact' do
     find_link(I18n.t('admin.buttons.delete_contact')).click
-    using_wait_time 1 do
+    using_wait_time 5 do
       expect(current_path).to eq admin_location_path(@location)
       expect(page).not_to have_link 'Moncef Belyamani'
     end

--- a/spec/features/admin/locations/delete_location_spec.rb
+++ b/spec/features/admin/locations/delete_location_spec.rb
@@ -10,7 +10,7 @@ feature 'Delete location' do
   scenario 'when submitting warning', :js do
     find_link(I18n.t('admin.buttons.delete_location')).click
     find_link(I18n.t('admin.buttons.confirm_delete_location')).click
-    using_wait_time 1 do
+    using_wait_time 5 do
       expect(current_path).to eq admin_locations_path
       expect(page).not_to have_link 'VRS Services'
     end

--- a/spec/features/admin/organizations/delete_contact_spec.rb
+++ b/spec/features/admin/organizations/delete_contact_spec.rb
@@ -11,7 +11,7 @@ feature 'Delete contact' do
 
   scenario 'when deleting contact' do
     find_link(I18n.t('admin.buttons.delete_contact')).click
-    using_wait_time 1 do
+    using_wait_time 5 do
       expect(current_path).to eq admin_organization_path(@org)
       expect(page).not_to have_link 'Moncef Belyamani'
     end

--- a/spec/features/admin/organizations/delete_organization_spec.rb
+++ b/spec/features/admin/organizations/delete_organization_spec.rb
@@ -10,7 +10,7 @@ feature 'Delete organization' do
   scenario 'when submitting warning', :js do
     find_link(I18n.t('admin.buttons.delete_organization')).click
     find_link(I18n.t('admin.buttons.confirm_delete_organization')).click
-    using_wait_time 2 do
+    using_wait_time 5 do
       expect(current_path).to eq admin_organizations_path
       expect(page).not_to have_link 'Parent Agency'
     end

--- a/spec/features/admin/programs/delete_program_spec.rb
+++ b/spec/features/admin/programs/delete_program_spec.rb
@@ -11,7 +11,7 @@ feature 'Delete program' do
   scenario 'when submitting warning', :js do
     find_link(I18n.t('admin.buttons.delete_program')).click
     find_link(I18n.t('admin.buttons.confirm_delete_program')).click
-    using_wait_time 1 do
+    using_wait_time 5 do
       expect(current_path).to eq admin_programs_path
     end
     expect(page).not_to have_link 'Collection of Services'

--- a/spec/features/admin/services/delete_contact_spec.rb
+++ b/spec/features/admin/services/delete_contact_spec.rb
@@ -12,7 +12,7 @@ feature 'Delete contact' do
 
   scenario 'when deleting contact' do
     find_link(I18n.t('admin.buttons.delete_contact')).click
-    using_wait_time 1 do
+    using_wait_time 5 do
       expect(current_path).to eq admin_location_service_path(@location, @service)
       expect(page).not_to have_link 'Moncef Belyamani'
     end

--- a/spec/features/admin/services/delete_service_spec.rb
+++ b/spec/features/admin/services/delete_service_spec.rb
@@ -11,7 +11,7 @@ feature 'Delete service' do
     click_link 'Literacy Program'
     find_link(I18n.t('admin.buttons.delete_service')).click
     find_link(I18n.t('admin.buttons.confirm_delete_service')).click
-    using_wait_time 1 do
+    using_wait_time 5 do
       expect(current_path).to eq admin_locations_path
     end
     click_link 'VRS Services'


### PR DESCRIPTION
**Why**: There have been some random failures in Circle CI, and they all seem to be for JS deletion specs. Increasing the wait time should fix this. Ideally, instead of checking the current path, we would look for content on the page, which will automatically use the default wait time, which is currently set to 10 seconds.