### PR TITLE
Add DB migration release phase to Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -C ./config/puma.rb
+release: bundle exec rake db:migrate


### PR DESCRIPTION
**Why**: To allow migrations to run automatically when deploying to Heroku, and to ensure that the build does not get deployed if the migration fails.

Reference: https://devcenter.heroku.com/articles/release-phase