### PR TITLE
Require default_host in ApplicationController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+require Rails.root.join('lib', 'default_host.rb')
+
 class ApplicationController < ActionController::Base
   include Pundit
   # Prevent CSRF attacks by raising an exception (with: :exception),


### PR DESCRIPTION
**Why**: In Rails 5, files outside `app` are no longer autoloaded after booting in the production environment.