### PR TITLE
Add .foreman to allow ‘foreman start’ locally

### DIFF
--- a/.foreman.example
+++ b/.foreman.example
@@ -1,0 +1,1 @@
+formation: release=0,web=1

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,4 @@ dump.rdb
 script/backup_mongo
 script/import_to_staging
 
-# Zeus
-.zeus.sock
+.foreman

--- a/bin/setup
+++ b/bin/setup
@@ -14,6 +14,11 @@ Dir.chdir APP_ROOT do
     system 'cp config/application.example.yml config/application.yml'
   end
 
+  unless File.exist?('.foreman')
+    puts '== Copying .foreman.example to .foreman =='
+    system 'cp .foreman.example .foreman'
+  end
+
   if ARGV.shift == "--docker" then
     exit
   end


### PR DESCRIPTION
**Why**: The release phase that was added recently doesn’t work in development and prevents the app from running with `foreman start`. One solution is to add a `.foreman` file that only applies locally (and is therefore gitignored) that tells Foreman to run without the release phase.