### PR TITLE
Make AssetHosts request argument optional

### DIFF
--- a/.reek
+++ b/.reek
@@ -15,6 +15,7 @@ NestedIterators:
 NilCheck:
   exclude:
     - ConfigValidator#required_keys_with_empty_values
+    - AssetHosts#call
 TooManyMethods:
   exclude:
     - Admin::CsvController

--- a/lib/asset_hosts.rb
+++ b/lib/asset_hosts.rb
@@ -1,5 +1,6 @@
 class AssetHosts
-  def call(_source, request)
+  def call(_source, request = nil)
+    return if request.nil?
     @request = request
     return asset_host_with_port if host_same_as_asset_host? || unauthorized_host?
     "#{subdomain}#{asset_host_with_port}"

--- a/spec/lib/asset_hosts_spec.rb
+++ b/spec/lib/asset_hosts_spec.rb
@@ -72,5 +72,9 @@ describe AssetHosts do
         expect(AssetHosts.new.call('image.png', request)).to eq 'www.example.com'
       end
     end
+
+    it 'returns nil if request argument is nil' do
+      expect(AssetHosts.new.call('image.png')).to be_nil
+    end
   end
 end


### PR DESCRIPTION
**Why**: In Rails 5.1, the request is not always supplied, for example when precompiling assets.
Reference: http://api.rubyonrails.org/classes/ActionView/Helpers/AssetUrlHelper.html