### PR TITLE
Use config instead of env vars in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,6 @@ jobs:
           RAILS_ENV: test
           CC_TEST_REPORTER_ID: 92362c9253cd1a4a5a164c83bf5157e6677fc1d91fee9b7a7690c1e1123fd87b
           COVERAGE: true
-          ADMIN_APP_TOKEN: testing123
-          API_PATH: api
-          ADMIN_PATH: admin
-          ASSET_HOST: example.com
-          DEFAULT_PER_PAGE: 30
-          DOMAIN_NAME: example.com
-          MAX_PER_PAGE: 50
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -68,6 +61,7 @@ jobs:
           name: Test Setup
           command: |
             psql -U circleci -q -d ohana_api_test -f db/structure.sql -h localhost -p 5432
+            cp config/application.example.yml config/application.yml
             bundle exec rake assets:precompile
 
       - run:


### PR DESCRIPTION
**Why**: To keep things DRY and consistent