### PR TITLE
Downcase admin_emails before saving

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -24,6 +24,7 @@ detectors:
     exclude:
       - ConfigValidator#required_keys_with_empty_values
       - AssetHosts#call
+      - Location#downcase_admin_emails
   TooManyMethods:
     exclude:
       - Admin::CsvController

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -53,6 +53,7 @@ class Location < ApplicationRecord
   validates :email, email: true, allow_blank: true
 
   after_validation :geocode, if: :needs_geocoding?
+  after_validation :downcase_admin_emails
 
   geocoded_by :full_physical_address
 
@@ -102,6 +103,10 @@ class Location < ApplicationRecord
     return true if latitude.blank? && longitude.blank?
 
     address.changed? && !address.new_record?
+  end
+
+  def downcase_admin_emails
+    admin_emails&.map!(&:downcase)
   end
 
   # See app/models/concerns/search.rb

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
     address
 
     factory :location_with_admin do
-      admin_emails { ['moncef@smcgov.org'] }
+      admin_emails { ['Moncef@smcgov.org'] }
       association :organization, factory: :nearby_org
     end
 


### PR DESCRIPTION
**Why**: In order to determine whether an admin user is able to edit
a particular location, their email address is compared to the list of
admin_emails associated with the location. When an admin account is
created, the email is automatically converted to lowercase. However,
when an admin email is added to a location, it does not get converted.

The current comparison looks for an exact match. To fix this issue, we
can either fix the comparison to be case insensitive, or automatically
convert admin emails to lowercase. The latter is the simplest
solution, and is what I implemented here.